### PR TITLE
パズル選択で 'その他・不明' -> '不明' に一旦戻す

### DIFF
--- a/app/views/basejs.scala.html
+++ b/app/views/basejs.scala.html
@@ -108,7 +108,7 @@ TriboxContest.formatPuzzle = function(results) {
     } else if (results.puzzle.type == 'nodatabase') {
         return results.puzzle.input;
     } else {
-        return 'その他・不明';
+        return '不明';
     }
 };
 

--- a/app/views/contestconfirm.scala.html
+++ b/app/views/contestconfirm.scala.html
@@ -126,17 +126,17 @@
                     </select>
                 </div>
 
-                <!--<label class="fancy-radio">
+                <label class="fancy-radio">
                     <input name="puzzle-type" type="radio" value="nodatabase" ng-model="puzzle.type">
                     <span>データベースに無いキューブを入力</span>
                 </label>
                 <div ng-show="puzzle.type == 'nodatabase'">
                     <input class="form-control" type="text" ng-model="puzzle.input">
-                </div>-->
+                </div>
 
                 <label class="fancy-radio">
                     <input name="puzzle-type" type="radio" value="unknown" ng-model="puzzle.type">
-                    <span>その他・不明</span>
+                    <span>不明</span>
                 </label>
             </div>
             <div class="col md-6">


### PR DESCRIPTION
https://github.com/tribox/tribox-contest/commit/268e68b8c3d5766fd246535490539291bb0c4db9 で入力できないようにしたけど、一旦戻す。急に入力できなくなったことの困惑をなくすため。パズルDB更新したら、またこれを戻す。また再び戻すときは、各ユーザーの「最近選択したパズル」からテキスト入力を削除しないといけないから忘れないようにする。