### PR TITLE
内蔵タイマーでのスペースキー長押し時間を0.35秒にしてみる

### DIFF
--- a/app/views/contesttimer.scala.html
+++ b/app/views/contesttimer.scala.html
@@ -334,7 +334,7 @@ app.controller('ContestTimerCtrl', ['$scope', '$timeout', function($scope, $time
     var startTouch = Infinity;
 
     var INSPECTION_SECOND = 15; @* /* インスペクションタイムは15秒 */ *@
-    var TOUCHING_TH = 500;      @* /* 0.5秒長押しでタイマースタート */ *@
+    var TOUCHING_TH = 350;      @* /* 0.35秒長押しでタイマースタート */ *@
     var LIMIT_SECOND = 600;     @* /* 10分でDNF */ *@
     var FREEZING_TH = 1000;     @* /* タイマーストップ後1秒はタイマースタートできない */ *@
 

--- a/app/views/contesttimerdemo.scala.html
+++ b/app/views/contesttimerdemo.scala.html
@@ -308,7 +308,7 @@ app.controller('ContestTimerCtrl', ['$scope', '$timeout', function($scope, $time
     var startTouch = Infinity;
 
     var INSPECTION_SECOND = 15; @* /* インスペクションタイムは15秒 */ *@
-    var TOUCHING_TH = 500;      @* /* 0.5秒長押しでタイマースタート */ *@
+    var TOUCHING_TH = 350;      @* /* 0.35秒長押しでタイマースタート */ *@
     var LIMIT_SECOND = 600;     @* /* 10分でDNF */ *@
     var FREEZING_TH = 1000;     @* /* タイマーストップ後1秒はタイマースタートできない */ *@
 


### PR DESCRIPTION
長らく0.5秒にしてたけど、0.5秒は相場からして長めな気がしてきたし、JSの実行環境によってはちょっと短めでもいいような気もしてきたから、DCTimerのデフォルト値にならって0.35秒にしてみる。