### PR TITLE
使用パズルのテキスト入力を廃止した（再び）

### DIFF
--- a/app/views/basejs.scala.html
+++ b/app/views/basejs.scala.html
@@ -108,7 +108,7 @@ TriboxContest.formatPuzzle = function(results) {
     } else if (results.puzzle.type == 'nodatabase') {
         return results.puzzle.input;
     } else {
-        return '不明';
+        return 'その他・不明';
     }
 };
 

--- a/app/views/contestconfirm.scala.html
+++ b/app/views/contestconfirm.scala.html
@@ -127,16 +127,8 @@
                 </div>
 
                 <label class="fancy-radio">
-                    <input name="puzzle-type" type="radio" value="nodatabase" ng-model="puzzle.type">
-                    <span>データベースに無いキューブを入力</span>
-                </label>
-                <div ng-show="puzzle.type == 'nodatabase'">
-                    <input class="form-control" type="text" ng-model="puzzle.input">
-                </div>
-
-                <label class="fancy-radio">
                     <input name="puzzle-type" type="radio" value="unknown" ng-model="puzzle.type">
-                    <span>不明</span>
+                    <span>その他・不明</span>
                 </label>
             </div>
             <div class="col md-6">
@@ -343,15 +335,8 @@ app.controller('ContestConfirmCtrl', ['$scope', '$timeout', function($scope, $ti
                 puzzle.brand = parseInt($scope.puzzle.brand);
                 puzzle.product = parseInt($scope.puzzle.product);
             } else if ($scope.puzzle.type == 'nodatabase') {
-                if (!($scope.puzzle.input) || $scope.puzzle.input.length <= 0) {
-                    $scope.error = 'キューブ名を入力してください。';
-                    return;
-                }
-                if (TriboxContest.INPUT_LENGTH.puzzleName.max < $scope.puzzle.input.length) {
-                    $scope.error = 'キューブ名は50文字以下で入力してください。';
-                    return;
-                }
-                puzzle.input = $scope.puzzle.input;
+                $scope.error = 'パズルを選択してください。';
+                return;
             } else if ($scope.puzzle.type == 'unknown') {
                 ;
             } else {


### PR DESCRIPTION
## 概要
データベースの準備が整ってきたため、使用パズルのテキスト入力を廃止した（再び）。

## History
* https://github.com/tribox/tribox-contest/commit/268e68b8c3d5766fd246535490539291bb0c4db9 で一旦廃止したけど、
* https://github.com/tribox/tribox-contest/pull/37 で一旦戻していた状態だった