### PR TITLE
Christmas Update 2018: トップページにシーズンランキングへのリンク

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -168,6 +168,7 @@
 
         <h5>過去のシーズンランキング</h5>
         <ul>
+            <li><a href="/ranking/20181">2018 前半期</a></li>
             <li><a href="/ranking/20172">2017 後半期</a></li>
             <li><a href="/ranking/20171">2017 前半期</a></li>
             <li><a href="/ranking/20162">2016 後半期</a></li>


### PR DESCRIPTION
トップページに2018年前半期のシーズンランキングへのリンクを掲載するを忘れていたので追加する。