### PR TITLE
Christmas Update 2018: タイマー6回目問題の応急処置

### DIFF
--- a/app/views/contestconfirm.scala.html
+++ b/app/views/contestconfirm.scala.html
@@ -245,7 +245,7 @@ app.controller('ContestConfirmCtrl', ['$scope', '$timeout', function($scope, $ti
             if (snapResult.exists()) {
                 var resultsData = snapResult.val();
                 $timeout(function() {
-                    $scope.result = calcResult(e.method, e.format, resultsData.details);
+                    $scope.result = calcResult(e.method, e.format, resultsData.details.slice(0, e.attempts));
                     // FMC: Calculate later
                     @if(eid == "333fm") {
                         $scope.result.condition = 'NOTYET';

--- a/app/views/contesttimer.scala.html
+++ b/app/views/contesttimer.scala.html
@@ -142,7 +142,7 @@ audiojs.events.ready(function() {
 });
 var a = audiojs.createAll();
 
-app.controller('ContestTimerCtrl', ['$scope', '$timeout', function($scope, $timeout) {
+app.controller('ContestTimerCtrl', ['$scope', '$timeout', '$interval', function($scope, $timeout, $interval) {
 
 @if(eid == "333fm") {
 
@@ -163,6 +163,16 @@ app.controller('ContestTimerCtrl', ['$scope', '$timeout', function($scope, $time
     //angular.element(document.getElementById('scramble-0')).removeClass('hide');
 
     var startPenalty = false;
+
+    // Forcefully show the button to the confirmation page whenever needed
+    $interval(function() {
+        if (window.TriboxContest.events.e@{eid}.attempts <= $scope.scrambleIndex) {
+            angular.element(document.getElementById('input-completed')).removeClass('hide');
+            document.getElementById('timerNote').innerHTML = window.TriboxContest.timerFinishText;
+            document.getElementById('timerNoteMb').innerHTML = window.TriboxContest.timerFinishText;
+            updateStatus(false, false, false);
+        }
+    }, 1000);
 
     // Set begin time
     var authData = contestRef.getAuth();

--- a/contestmanager/collect-results.js
+++ b/contestmanager/collect-results.js
@@ -748,7 +748,7 @@ var checkResults = function() {
                             Object.keys(results[eid]).forEach(function(uid) {
                                 if (!(results[eid][uid]._dummy) && results[eid][uid].endAt) {
                                     //console.dir(results[eid][uid]);
-                                    var result = calcResult(Events[eid].method, Events[eid].format, results[eid][uid].details);
+                                    var result = calcResult(Events[eid].method, Events[eid].format, results[eid][uid].details.slice(0, Events[eid].attempts));
                                     //console.dir(result);
 
                                     var _ready = {


### PR DESCRIPTION
内蔵タイマー6回目突入問題 #25 の応急処置。
本来は非同期関数の組み合わせで予期しないステートに遷移しているのが原因だと推測されるが、再現もデバッグも難しいので応急処置する。

`$interval` で規定試技数以上の計測がされていたら、強制的に確認ページへのリンクボタンを出す。

また、それに関連して、平均等の計算する関数 (calcResult) に与えるデータを正しく試技数分にスライスする。