### PR TITLE
メニューバーとコンテスト結果画面の文言を変更

### DIFF
--- a/app/views/bodyheader.scala.html
+++ b/app/views/bodyheader.scala.html
@@ -41,16 +41,16 @@
             <a href="@routes.HomeController.about">トリコンとは</a>
         </div>
         <div id="main-menu-2" class="col sm-3">
-            <a href="/contest/{{ inProgress.lastContest | removeHead }}" ng-show="inProgress.lastContest != 'cxxxxxxx'">最新コンテスト結果</a>
-            <a href="#" ng-show="inProgress.lastContest == 'cxxxxxxx'">最新コンテスト結果</a>
+            <a href="/contest/{{ inProgress.lastContest | removeHead }}" ng-show="inProgress.lastContest != 'cxxxxxxx'">リザルト</a>
+            <a href="#" ng-show="inProgress.lastContest == 'cxxxxxxx'">リザルト</a>
         </div>
         <div id="main-menu-3" class="col sm-3">
-            <a href="/ranking/{{ inProgressContest.year }}{{ inProgressContest.season }}" ng-show="inProgress.lastContest != 'cxxxxxxx'">シーズンランキング</a>
-            <a href="#" ng-show="inProgress.lastContest == 'cxxxxxxx'">シーズンランキング</a>
+            <a href="/ranking/{{ inProgressContest.year }}{{ inProgressContest.season }}" ng-show="inProgress.lastContest != 'cxxxxxxx'">SPランキング</a>
+            <a href="#" ng-show="inProgress.lastContest == 'cxxxxxxx'">SPランキング</a>
         </div>
         <div id="main-menu-4" class="col sm-3">
-            <a href="/ranking/{{ inProgressContest.year }}{{ inProgressContest.season }}/puzzle" ng-show="inProgress.lastContest != 'cxxxxxxx'">パズル使用率ランキング</a>
-            <a href="#" ng-show="inProgress.lastContest == 'cxxxxxxx'">パズル使用率ランキング</a>
+            <a href="/ranking/{{ inProgressContest.year }}{{ inProgressContest.season }}/puzzle" ng-show="inProgress.lastContest != 'cxxxxxxx'">パズルシェア</a>
+            <a href="#" ng-show="inProgress.lastContest == 'cxxxxxxx'">パズルシェア</a>
         </div>
     </div>
 <script>

--- a/app/views/contest.scala.html
+++ b/app/views/contest.scala.html
@@ -116,7 +116,7 @@
                 <table class="table table-bordered result tribox-contest">
                     <thead>
                         <tr>
-                            <th>順位</th>
+                            <th><i class="fa fa-hashtag"></i></th>
                             <th>SP</th>
                             <th>名前</th>
                             <th class="mb-hide">所属</th>

--- a/app/views/contest.scala.html
+++ b/app/views/contest.scala.html
@@ -117,15 +117,15 @@
                     <thead>
                         <tr>
                             <th>順位</th>
-                            <th>獲得SP</th>
+                            <th>SP</th>
                             <th>名前</th>
                             <th class="mb-hide">所属</th>
-                            <th ng-if="e != 'e333fm' && (events[e].method == 'average' || events[e].method == 'mean')">平均記録</th>
-                            <th ng-if="e != 'e333fm' && events[e].method == 'best'">最高記録</th>
+                            <th ng-if="e != 'e333fm' && (events[e].method == 'average' || events[e].method == 'mean')">記録</th>
+                            <th ng-if="e != 'e333fm' && events[e].method == 'best'">記録</th>
                             <th ng-if="e == 'e333fm'">記録</th>
-                            <th class="mb-hide" ng-if="e != 'e333fm'">個々の記録</th>
-                            <th class="mb-hide" ng-if="e == 'e333fm'">解答・解説コメント</th>
-                            <th>使用キューブ</th>
+                            <th class="mb-hide" ng-if="e != 'e333fm'"></th>
+                            <th class="mb-hide" ng-if="e == 'e333fm'"></th>
+                            <th>パズル</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -140,7 +140,8 @@
                             <td class="mb-hide">{{ r.user.organization }}</td>
                             <td class="mb-hide"><b>{{ r.resultF }}</b></td>
                             <td class="tb-hide pc-hide"><a class="cursor-pointer" ng-click="showDetail(e, $index)"><b style="color: rgb(85, 85, 85);">{{ r.resultF }}</b></a></td>
-                            <td class="mb-hide" id="{{ e }}-{{ $index }}-show"><a class="cursor-pointer" ng-click="showDetail(e, $index)">表示</a></td>
+                            <td class="mb-hide" id="{{ e }}-{{ $index }}-show" ng-if="e != 'e333fm'"><a class="cursor-pointer" ng-click="showDetail(e, $index)">詳細</a></td>
+                            <td class="mb-hide" id="{{ e }}-{{ $index }}-show" ng-if="e == 'e333fm'"><a class="cursor-pointer" ng-click="showDetail(e, $index)">解答</a></td>
                             <td ng-show="r.puzzle.type == 'database'">
                                 <a href="http://store.tribox.com/products/detail.php?product_id={{ r.puzzle.product }}" target="_blank">{{ r.puzzleF }}</a>
                             </td>

--- a/app/views/contest.scala.html
+++ b/app/views/contest.scala.html
@@ -120,11 +120,8 @@
                             <th>SP</th>
                             <th>名前</th>
                             <th class="mb-hide">所属</th>
-                            <th ng-if="e != 'e333fm' && (events[e].method == 'average' || events[e].method == 'mean')">記録</th>
-                            <th ng-if="e != 'e333fm' && events[e].method == 'best'">記録</th>
-                            <th ng-if="e == 'e333fm'">記録</th>
-                            <th class="mb-hide" ng-if="e != 'e333fm'"></th>
-                            <th class="mb-hide" ng-if="e == 'e333fm'"></th>
+                            <th>記録</th>
+                            <th class="mb-hide"></th>
                             <th>パズル</th>
                         </tr>
                     </thead>

--- a/app/views/contestresult.scala.html
+++ b/app/views/contestresult.scala.html
@@ -161,14 +161,8 @@ var drawChart = function(dataall, data) {
                     <th>SP</th>
                     <th>名前</th>
                     <th class="mb-hide">所属</th>
-                    @if(eid != "333fm") {
-                        <th ng-if="events.e@{eid}.method == 'average' || events.e@{eid}.method == 'mean'">記録</th>
-                        <th ng-if="events.e@{eid}.method == 'best'">記録</th>
-                        <th class="mb-hide"></th>
-                    } else {
-                        <th>記録</th>
-                        <th class="mb-hide"></th>
-                    }
+                    <th>記録</th>
+                    <th class="mb-hide"></th>
                     <th>パズル</th>
                     <th><i class="fa fa-video-camera"></i></th>
                 </tr>

--- a/app/views/contestresult.scala.html
+++ b/app/views/contestresult.scala.html
@@ -158,18 +158,18 @@ var drawChart = function(dataall, data) {
             <thead>
                 <tr>
                     <th>順位</th>
-                    <th>獲得SP</th>
+                    <th>SP</th>
                     <th>名前</th>
                     <th class="mb-hide">所属</th>
                     @if(eid != "333fm") {
-                        <th ng-if="events.e@{eid}.method == 'average' || events.e@{eid}.method == 'mean'">平均記録</th>
-                        <th ng-if="events.e@{eid}.method == 'best'">最高記録</th>
-                        <th class="mb-hide">個々の記録</th>
+                        <th ng-if="events.e@{eid}.method == 'average' || events.e@{eid}.method == 'mean'">記録</th>
+                        <th ng-if="events.e@{eid}.method == 'best'">記録</th>
+                        <th class="mb-hide"></th>
                     } else {
                         <th>記録</th>
-                        <th class="mb-hide">解答・解説コメント</th>
+                        <th class="mb-hide"></th>
                     }
-                    <th>使用キューブ</th>
+                    <th>パズル</th>
                     <th><i class="fa fa-video-camera"></i></th>
                 </tr>
             </thead>
@@ -191,7 +191,11 @@ var drawChart = function(dataall, data) {
                     <td class="mb-hide">{{ r.user.organization }}</td>
                     <td class="mb-hide"><b>{{ r.resultF }}</b></td>
                     <td class="tb-hide pc-hide"><a class="cursor-pointer" ng-click="showDetail($index)"><b style="color: rgb(85, 85, 85);">{{ r.resultF }}</b></a></td>
-                    <td id="e@{eid}-{{ $index }}-show" class="mb-hide"><a class="cursor-pointer" ng-click="showDetail($index)">表示</a></td>
+                    @if(eid != "333fm") {
+                        <td id="e@{eid}-{{ $index }}-show" class="mb-hide"><a class="cursor-pointer" ng-click="showDetail($index)">詳細</a></td>
+                    } else {
+                        <td id="e@{eid}-{{ $index }}-show" class="mb-hide"><a class="cursor-pointer" ng-click="showDetail($index)">解答</a></td>
+                    }
                     <td ng-show="r.puzzle.type == 'database'">
                         <a href="http://store.tribox.com/products/detail.php?product_id={{ r.puzzle.product }}" target="_blank">{{ r.puzzleF }}</a>
                     </td>

--- a/app/views/contestresult.scala.html
+++ b/app/views/contestresult.scala.html
@@ -157,7 +157,7 @@ var drawChart = function(dataall, data) {
         <table class="table table-bordered result tribox-contest">
             <thead>
                 <tr>
-                    <th>順位</th>
+                    <th><i class="fa fa-hashtag"></i></th>
                     <th>SP</th>
                     <th>名前</th>
                     <th class="mb-hide">所属</th>


### PR DESCRIPTION
### Issue

Closes #115 

### 内容

以下の項目名を変更

- メニューバーの項目名
- コンテスト結果サマリー画面（「リザルト」から飛ぶコンテスト結果のサマリー画面）
- コンテスト種目別結果画面（コンテスト結果サマリー画面->「〇〇のすべての結果を見る」）

### 確認箇所

- [ ] メニューバーの項目
- (https://contest-dev.tribox.com/contest/2016121) 
  - [ ] FMC以外の項目名、リンクが「詳細」になっていること
  - [ ] FMCの項目名、リンクが「解答」になっていること
- [ ] (https://contest-dev.tribox.com/contest/result/2016121/333)
  - 項目名、リンクが「詳細」になっていること
- [ ] (https://contest-dev.tribox.com/contest/result/2016121/333fm)
  - 項目名、リンクが「解答」になっていること