### PR TITLE
所属を1行で表示、480px以下でビデオの列を非表示に

### DIFF
--- a/app/views/contest.scala.html
+++ b/app/views/contest.scala.html
@@ -134,7 +134,7 @@
                                 <img src="@routes.Assets.versioned("flags/flags-iso/shiny/24")/{{ r.user.iso2 }}.png" height="24" style="vertical-align: middle;" ng-show="r.user.iso2">
                                 <a href="/user/{{ r.user.username }}">{{ r.user.displayname }}</a>
                             </td>
-                            <td class="mb-hide">{{ r.user.organization }}</td>
+                            <td class="mb-hide ellipsis">{{ r.user.organization }}</td>
                             <td class="mb-hide"><b>{{ r.resultF }}</b></td>
                             <td class="tb-hide pc-hide"><a class="cursor-pointer" ng-click="showDetail(e, $index)"><b style="color: rgb(85, 85, 85);">{{ r.resultF }}</b></a></td>
                             <td class="mb-hide" id="{{ e }}-{{ $index }}-show" ng-if="e != 'e333fm'"><a class="cursor-pointer" ng-click="showDetail(e, $index)">詳細</a></td>

--- a/app/views/contestresult.scala.html
+++ b/app/views/contestresult.scala.html
@@ -182,7 +182,7 @@ var drawChart = function(dataall, data) {
                         <img src="@routes.Assets.versioned("flags/flags-iso/shiny/24")/{{ r.user.iso2 }}.png" height="24" style="vertical-align: middle;" ng-show="r.user.iso2">
                         <a href="/user/{{ r.user.username }}">{{ r.user.displayname }}</a>
                     </td>
-                    <td class="mb-hide">{{ r.user.organization }}</td>
+                    <td class="mb-hide ellipsis">{{ r.user.organization }}</td>
                     <td class="mb-hide"><b>{{ r.resultF }}</b></td>
                     <td class="tb-hide pc-hide"><a class="cursor-pointer" ng-click="showDetail($index)"><b style="color: rgb(85, 85, 85);">{{ r.resultF }}</b></a></td>
                     @if(eid != "333fm") {

--- a/app/views/contestresult.scala.html
+++ b/app/views/contestresult.scala.html
@@ -164,7 +164,7 @@ var drawChart = function(dataall, data) {
                     <th>記録</th>
                     <th class="mb-hide"></th>
                     <th>パズル</th>
-                    <th><i class="fa fa-video-camera"></i></th>
+                    <th class="mb-hide"><i class="fa fa-video-camera"></i></th>
                 </tr>
             </thead>
             <tbody>
@@ -196,10 +196,10 @@ var drawChart = function(dataall, data) {
                     <td ng-show="r.puzzle.type == 'nodatabase' || r.puzzle.type == 'unknown'">
                         {{ r.puzzleF }}
                     </td>
-                    <td ng-if="r.videoUrl">
+                    <td class="mb-hide" ng-if="r.videoUrl">
                         <a href="{{ r.videoUrl | encodeURI }}" target="_blank"><i class="fa fa-video-camera"></i></a>
                     </td>
-                    <td ng-if="!(r.videoUrl)"></td>
+                    <td class="mb-hide" ng-if="!(r.videoUrl)"></td>
                 </tr>
             </tbody>
         </table>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -369,6 +369,13 @@ tr.row-detail {
     color: #E3CF7A;
 }
 
+td.ellipsis {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    width: 30%;
+    max-width: 0;
+}
 
 /**
  * Profile table


### PR DESCRIPTION
### Issue

Closes #117 

### やったこと

- main.cssにtd.ellipsisクラスを作成
- リザルト画面（全体と種目別）の「所属」の列にellipsisクラスを追加
- ビデオの列にmb-hideクラスを追加

### 見る場所

- [ ] リザルト画面（全体）の「所属」列
- [ ] リザルト画面（種目別）の「所属」列
- [ ] リザルト画面（種目別）、画面幅480px以下でも表示崩れがないこと