### PR TITLE
計測開始から0.2秒以内にタイマーストップしないよう変更

### DIFF
--- a/app/views/contesttimer.scala.html
+++ b/app/views/contesttimer.scala.html
@@ -412,6 +412,7 @@ firebase.auth().onAuthStateChanged(function(authData) {
     var TOUCHING_TH = 350;      @* /* 0.35秒長押しでタイマースタート */ *@
     var LIMIT_SECOND = 600;     @* /* 10分でDNF */ *@
     var FREEZING_TH = 1000;     @* /* タイマーストップ後1秒はタイマースタートできない */ *@
+    var REJECTING_STOPTIMER_TH = 200;   @* /* 計測開始後0.2秒はタッチ操作で計測終了できない */ *@
 
     //var startButton = document.getElementById('start');
     //var stopButton = document.getElementById('stop');
@@ -623,7 +624,7 @@ firebase.auth().onAuthStateChanged(function(authData) {
             touchX = e.changedTouches[0].pageX;
             touchY = e.changedTouches[0].pageY;
             hasInspection = window.TriboxContest.hasInspection;
-            if (isRunning) {
+            if (isRunning && REJECTING_STOPTIMER_TH < Date.now() - startTime) {
                 stopTimer();
                 unShowOnlyTimer();
                 isTouchingStop = true;

--- a/app/views/contesttimer.scala.html
+++ b/app/views/contesttimer.scala.html
@@ -577,7 +577,7 @@ firebase.auth().onAuthStateChanged(function(authData) {
     document.addEventListener('keydown', function(e) {
         //document.getElementById('keydown').innerHTML = e.keyCode + ':' + e.code + ' (' + Date.now() + ')';
         hasInspection = window.TriboxContest.hasInspection;
-        if (isRunning) {
+        if (isRunning && REJECTING_STOPTIMER_TH < Date.now() - startTime) {
             stopTimer();
             unShowOnlyTimer();
             isTouchingStop = true;

--- a/app/views/contesttimerdemo.scala.html
+++ b/app/views/contesttimerdemo.scala.html
@@ -540,7 +540,7 @@ firebase.auth().onAuthStateChanged(function(authData) {
     document.addEventListener('keydown', function(e) {
         //document.getElementById('keydown').innerHTML = e.keyCode + ':' + e.code + ' (' + Date.now() + ')';
         hasInspection = window.TriboxContest.hasInspection;
-        if (isRunning) {
+        if (isRunning && REJECTING_STOPTIMER_TH < Date.now() - startTime) {
             stopTimer();
             unShowOnlyTimer();
             isTouchingStop = true;

--- a/app/views/contesttimerdemo.scala.html
+++ b/app/views/contesttimerdemo.scala.html
@@ -375,6 +375,7 @@ firebase.auth().onAuthStateChanged(function(authData) {
     var TOUCHING_TH = 350;      @* /* 0.35秒長押しでタイマースタート */ *@
     var LIMIT_SECOND = 600;     @* /* 10分でDNF */ *@
     var FREEZING_TH = 1000;     @* /* タイマーストップ後1秒はタイマースタートできない */ *@
+    var REJECTING_STOPTIMER_TH = 200;   @* /* 計測開始後0.2秒はタッチ操作で計測終了できない */ *@
 
     //var startButton = document.getElementById('start');
     //var stopButton = document.getElementById('stop');
@@ -586,7 +587,7 @@ firebase.auth().onAuthStateChanged(function(authData) {
             touchX = e.changedTouches[0].pageX;
             touchY = e.changedTouches[0].pageY;
             hasInspection = window.TriboxContest.hasInspection;
-            if (isRunning) {
+            if (isRunning && REJECTING_STOPTIMER_TH < Date.now() - startTime) {
                 stopTimer();
                 unShowOnlyTimer();
                 isTouchingStop = true;


### PR DESCRIPTION
## 👏 解決するIssue

 - #127 

## ⛏️ 変更箇所

 - コンテスト用タイマーのkeydownリスナー、touchstartリスナー
 - 練習用タイマーのkeydownリスナー、touchstartリスナー