### PR TITLE
コンテスト結果ページのパズル使用率をPCでも棒グラフに統一

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -610,13 +610,20 @@ a.contestresult-puzzle-name:hover {
     height: 40px;
   }
 
+  .contestresult-puzzle-chart {
+    display: none;
+  }
+
   .contestresult-puzzle-color-wrapper {
-    width: 16px;
+    width: 100px;
     height: 16px;
+    display: flex;
+    justify-content: flex-end;
   }
 
   .contestresult-puzzle-color {
-    width: 100% !important;
+    border-radius: 4px;
+    min-width: 4px;
   }
 
   .contestresult-info-title {

--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -210,16 +210,6 @@
   box-sizing: content-box;
 }
 
-/* 円グラフツールチップ */
-.contestresult-puzzle-chart .c3-tooltip {
-  white-space: nowrap;
-  font-size: 12px;
-}
-
-.contestresult-puzzle-chart .c3-tooltip td {
-  padding: 4px 8px;
-}
-
 .contestresult-puzzle-section {
   margin-bottom: 16px;
 }
@@ -244,14 +234,6 @@
   min-width: 0;
 }
 
-.contestresult-puzzle-chart {
-  width: 280px;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .contestresult-puzzle-item {
   display: flex;
   align-items: center;
@@ -260,16 +242,18 @@
 }
 
 .contestresult-puzzle-color-wrapper {
-  width: 16px;
+  width: 100px;
   height: 16px;
   flex-shrink: 0;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .contestresult-puzzle-color {
   display: block;
-  width: 100%;
   height: 100%;
-  border-radius: 2px;
+  border-radius: 4px;
+  min-width: 4px;
 }
 
 .contestresult-puzzle-brand,
@@ -610,22 +594,6 @@ a.contestresult-puzzle-name:hover {
     height: 40px;
   }
 
-  .contestresult-puzzle-chart {
-    display: none;
-  }
-
-  .contestresult-puzzle-color-wrapper {
-    width: 100px;
-    height: 16px;
-    display: flex;
-    justify-content: flex-end;
-  }
-
-  .contestresult-puzzle-color {
-    border-radius: 4px;
-    min-width: 4px;
-  }
-
   .contestresult-info-title {
     font-size: 24px;
   }
@@ -725,23 +693,6 @@ a.contestresult-puzzle-name:hover {
   .contestresult-picker-event-item {
     width: 48px;
     height: 48px;
-  }
-
-  .contestresult-puzzle-chart {
-    display: none;
-  }
-
-
-  .contestresult-puzzle-color-wrapper {
-    width: 100px;
-    height: 16px;
-    display: flex;
-    justify-content: flex-end;
-  }
-
-  .contestresult-puzzle-color {
-    border-radius: 4px;
-    min-width: 4px;
   }
 
   .contestresult-puzzle-name,

--- a/src/templates/components/contestjs.html
+++ b/src/templates/components/contestjs.html
@@ -465,13 +465,11 @@ fetch_results_all=False) -%]
                               });
                               // 上位5パズル以外はその他にする
                               var _resultsPuzzlesAllSummary = [];
-                              var jsdataall = [];
                               var countOthersAll = 0;
                               _resultsPuzzlesAll.forEach(function(puzzleObj, index) {
                                   if (index < 5) {
                                       puzzleObj.percentage = Math.round(puzzleObj.count / _resultsPuzzlesAllSum * 100);
                                       _resultsPuzzlesAllSummary.push(puzzleObj);
-                                      jsdataall.push([puzzleObj.productName, puzzleObj.count]);
                                   } else {
                                       countOthersAll += puzzleObj.count;
                                   }
@@ -483,7 +481,6 @@ fetch_results_all=False) -%]
                                       'count': countOthersAll,
                                       'percentage': Math.round(countOthersAll / _resultsPuzzlesAllSum * 100)
                                   });
-                                  jsdataall.push(['その他', countOthersAll]);
                               }
                               $scope.resultsPuzzlesAll['e[[ eid ]]'] = _resultsPuzzlesAllSummary;
 
@@ -502,13 +499,11 @@ fetch_results_all=False) -%]
                               });
                               // 上位5パズル以外はその他にする
                               var _resultsPuzzlesSummary = [];
-                              var jsdata = [];
                               var countOthers = 0;
                               _resultsPuzzles.forEach(function(puzzleObj, index) {
                                   if (index < 5) {
                                       puzzleObj.percentage = Math.round(puzzleObj.count / _resultsPuzzlesSum * 100);
                                       _resultsPuzzlesSummary.push(puzzleObj);
-                                      jsdata.push([puzzleObj.productName, puzzleObj.count]);
                                   } else {
                                       countOthers += puzzleObj.count;
                                   }
@@ -520,12 +515,8 @@ fetch_results_all=False) -%]
                                       'count': countOthers,
                                       'percentage': Math.round(countOthers / _resultsPuzzlesSum * 100)
                                   });
-                                  jsdata.push(['その他', countOthers]);
                               }
                               $scope.resultsPuzzles['e[[ eid ]]'] = _resultsPuzzlesSummary;
-
-                              // 円グラフ描画
-                              drawChart(jsdataall, jsdata);
 
                           });
                       });

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -9,20 +9,6 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
     [% import "components/header.html" as header %] [[ header.print(title=title,
     description=contest_description, sitename=contest_name,
     contest_url=contest_url, page_url=page_url) ]]
-    <!-- Load c3.css -->
-    <link
-      href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.css"
-      rel="stylesheet"
-      type="text/css"
-    />
-
-    <!-- Load d3.js and c3.js -->
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"
-      charset="utf-8"
-    ></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js"></script>
-
     [% import "components/basejs.html" as basejs %] [[
     basejs.print(firebaseapp_contest, firebaseapp_contest_apikey,
     firebaseapp_contest_senderid, firebaseapp_wca) ]]
@@ -82,9 +68,6 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                 <div class="contestresult-puzzle-section">
                   <div class="contestresult-puzzle-section-title contestresult-hide-mobile">参加者全員のパズル</div>
                   <div class="contestresult-puzzle-content">
-                    <div class="contestresult-puzzle-chart">
-                      <div id="chartall"></div>
-                    </div>
                     <div class="contestresult-puzzle-list">
                       <div
                         class="contestresult-puzzle-item"
@@ -118,9 +101,6 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                 <div class="contestresult-puzzle-section">
                   <div class="contestresult-puzzle-section-title contestresult-hide-mobile">入賞者のパズル</div>
                   <div class="contestresult-puzzle-content">
-                    <div class="contestresult-puzzle-chart">
-                      <div id="chart"></div>
-                    </div>
                     <div class="contestresult-puzzle-list">
                       <div
                         class="contestresult-puzzle-item"
@@ -150,80 +130,6 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                     </div>
                   </div>
                 </div>
-
-                <!-- <h4>キューブ使用率ランキング</h4>
-                <div class="row">
-                  <div class="col sm-12"><b>集計対象: 参加者全員</b></div>
-                  <div class="col sm-4">
-                    <ol>
-                      <li ng-repeat="p in resultsPuzzlesAll.e[[ eid ]]">
-                        <a
-                          href="https://store.tribox.com/products/detail.php?product_id={{ p.productId }}"
-                          target="_blank"
-                          ng-show="p.productId != -1"
-                        >
-                          {{ p.productName }}
-                        </a>
-                        <span ng-show="p.productId == -1"> その他 </span>
-                        ({{ p.percentage }}%)
-                      </li>
-                    </ol>
-                  </div>
-                  <div class="col sm-8">
-                    <div id="chartall"></div>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col sm-12"><b>集計対象: 入賞者</b></div>
-                  <div class="col sm-4">
-                    <ol>
-                      <li ng-repeat="p in resultsPuzzles.e[[ eid ]]">
-                        <a
-                          href="https://store.tribox.com/products/detail.php?product_id={{ p.productId }}"
-                          target="_blank"
-                          ng-show="p.productId != -1"
-                        >
-                          {{ p.productName }}
-                        </a>
-                        <span ng-show="p.productId == -1"> その他 </span>
-                        ({{ p.percentage }}%)
-                      </li>
-                    </ol>
-                  </div>
-                  <div class="col sm-8">
-                    <div id="chart"></div>
-                  </div>
-                </div>
-                <script>
-                  var drawChart = function (dataall, data) {
-                    if (0 < dataall.length) {
-                      var chart = c3.generate({
-                        bindto: "#chartall",
-                        data: {
-                          columns: dataall,
-                          type: "pie",
-                          order: null,
-                        },
-                        size: {
-                          height: 240,
-                        },
-                      });
-                    }
-                    if (0 < data.length) {
-                      var chart = c3.generate({
-                        bindto: "#chart",
-                        data: {
-                          columns: data,
-                          type: "pie",
-                          order: null,
-                        },
-                        size: {
-                          height: 240,
-                        },
-                      });
-                    }
-                  };
-                </script> -->
 
                 <!-- <h4>コンテスト結果</h4>
                 <p><i class="fa fa-star color-star"></i>: 当選ポイント獲得</p> -->
@@ -390,45 +296,8 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
               $scope.contestResultLoaded = true;
             });
 
-            // 円グラフ描画 (contestjs.html から drawChart が呼ばれる)
-            var pieColors = ["#2690D9", "#E87D7E", "#FF8000", "#29A329", "#B470C2"];
-            $scope.puzzleColors = pieColors;
-            var pieOtherColor = "#808080";
-
-            function getPieColorMap(columns) {
-              var map = {};
-              columns.forEach(function(col, i) {
-                if (col[0] === "その他") {
-                  map[col[0]] = pieOtherColor;
-                } else {
-                  map[col[0]] = pieColors[i] || pieOtherColor;
-                }
-              });
-              return map;
-            }
-
-            window.drawChart = function(dataall, data) {
-              if (dataall && dataall.length > 0) {
-                c3.generate({
-                  bindto: "#chartall",
-                  data: { columns: dataall, type: "pie", order: null, labels: false, colors: getPieColorMap(dataall) },
-                  size: { height: 240 },
-                  legend: { show: false },
-                  pie: { label: { show: false } },
-                  tooltip: { format: { value: function(v) { return v + "%"; } } }
-                });
-              }
-              if (data && data.length > 0) {
-                c3.generate({
-                  bindto: "#chart",
-                  data: { columns: data, type: "pie", order: null, labels: false, colors: getPieColorMap(data) },
-                  size: { height: 240 },
-                  legend: { show: false },
-                  pie: { label: { show: false } },
-                  tooltip: { format: { value: function(v) { return v + "%"; } } }
-                });
-              }
-            };
+            // パズルバーの色
+            $scope.puzzleColors = ["#2690D9", "#E87D7E", "#FF8000", "#29A329", "#B470C2"];
 
             [% if eid == "333fm" %]
             var showDetailList = [];


### PR DESCRIPTION
## 概要
コンテスト結果ページ (`/contest/result/<cid>/<eid>`) のパズル使用率の表示を、PC・スマホともに棒グラフに統一しました。

これまではPCで円グラフ（c3.js）、スマホで棒グラフと表示が分かれていましたが、スマホと同じ棒グラフに揃えてほしいという要望に対応したものです。

## 変更内容
- **PCでも棒グラフ表示に**: 色チップを16pxの四角ドットから、使用率に応じた幅の棒に変更（スマホと同じ見た目）
- **円グラフ（c3.js）を削除**: 表示されなくなったため、関連コードを一式撤去
  - `contestresult.html`: チャート用 `div`（`#chartall` / `#chart`）、`drawChart`・`getPieColorMap`、c3.css / d3.js / c3.js のCDN読み込み、旧コメントアウト済みの円グラフブロック
  - `contestjs.html`: 円グラフ専用だった `jsdataall` / `jsdata` の生成と `drawChart()` 呼び出し（このパスを通るのは結果ページのみのため他ページへの影響なし）
  - `contestresult.css`: `.contestresult-puzzle-chart` とツールチップのルールを削除し、棒グラフのスタイルをベースに統合（PC/スマホで重複していたメディアクエリも整理）
- バーの色付けに使う `puzzleColors` と、使用率計算の `percentage` はそのまま維持

## スクリーンショット

<img width="1800" height="1008" alt="Screenshot 2026-06-16 at 22 26 43" src="https://github.com/user-attachments/assets/f09c9c9c-f100-4827-b4cc-faa9f86bdb49" />


## 動作確認
- [x] PC画面で円グラフが消え、棒グラフで表示される
- [x] スマホ画面は従来どおり棒グラフで表示される
- [x] 「参加者全員のパズル」「入賞者のパズル」両方とも正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)