### PR TITLE
products.js を静的ファイル配信に変更し gitignore 対象に

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ target
 # SSL auth file
 fileauth.txt
 fileauth_*.txt
+
+# 本番環境で都度生成される動的JS
+/src/public/javascripts/products.js

--- a/src/app.py
+++ b/src/app.py
@@ -650,32 +650,11 @@ def demo_timer():
 
 
 ########################################
-# Dynamic JavaScripts
+# Static JavaScripts
 ########################################
 @app.route("/js/products.js")
 def products_js():
-    # Store DB から商品情報を取得
-    # TODO: これはとりあえずの実装なのでDBへのコネクションはコネクションプールを使うなどしたい
-    with get_store_db_connection() as conn:
-        with conn.cursor() as cursor:
-            cursor.execute(
-                "SELECT `product_id`, `name`" \
-                " FROM `dtb_products`" \
-                " WHERE `del_flg` != 1" \
-                " ORDER BY `product_id` ASC"
-            )
-            products = cursor.fetchall()
-
-    # 動的javascriptのテンプレート読み込み
-    rendered_js = render_template("javascripts/products.js", products=products)
-
-    # Content-Typeを "application/javascript" としてレスポンス作成＆返却
-    # Cache-Controlヘッダ: 1時間のキャッシュを許可
-    response = make_response(rendered_js)
-    response.headers["Content-Type"] = "application/javascript; charset=utf-8"
-    response.headers["Cache-Control"] = "public, max-age=3600"
-
-    return response
+    return app.send_static_file("javascripts/products.js")
 
 
 ########################################


### PR DESCRIPTION
## 概要
`/js/products.js` のルートが読み込まれない問題を修正しました。あわせて、本番環境で都度生成される `products.js` を Git の管理対象外にしました。

## 変更内容
- **`app.py`**: `/js/products.js` を store DB から毎回動的レンダリングする実装から、事前生成済みの静的ファイルを配信する実装に変更しました（`send_static_file`）。これにより products.js が正しく読み込まれるようになりました。
- **`.gitignore`**: `/src/public/javascripts/products.js` を追加しました。本番環境で都度生成されるファイルのため、手元で生成→コミット時に毎回削除する手間をなくしました。

## 補足
- `products.js` は各環境で生成される想定のため、リポジトリには含めていません。