### PR TITLE
Revert "products.js を静的ファイル配信に変更し gitignore 対象に" (#224)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,3 @@ target
 # SSL auth file
 fileauth.txt
 fileauth_*.txt
-
-# 本番環境で都度生成される動的JS
-/src/public/javascripts/products.js

--- a/src/app.py
+++ b/src/app.py
@@ -650,11 +650,32 @@ def demo_timer():
 
 
 ########################################
-# Static JavaScripts
+# Dynamic JavaScripts
 ########################################
 @app.route("/js/products.js")
 def products_js():
-    return app.send_static_file("javascripts/products.js")
+    # Store DB から商品情報を取得
+    # TODO: これはとりあえずの実装なのでDBへのコネクションはコネクションプールを使うなどしたい
+    with get_store_db_connection() as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT `product_id`, `name`" \
+                " FROM `dtb_products`" \
+                " WHERE `del_flg` != 1" \
+                " ORDER BY `product_id` ASC"
+            )
+            products = cursor.fetchall()
+
+    # 動的javascriptのテンプレート読み込み
+    rendered_js = render_template("javascripts/products.js", products=products)
+
+    # Content-Typeを "application/javascript" としてレスポンス作成＆返却
+    # Cache-Controlヘッダ: 1時間のキャッシュを許可
+    response = make_response(rendered_js)
+    response.headers["Content-Type"] = "application/javascript; charset=utf-8"
+    response.headers["Cache-Control"] = "public, max-age=3600"
+
+    return response
 
 
 ########################################


### PR DESCRIPTION
## 概要

PR #224 (`fix-products-js-loading`) をリバートします。

`/js/products.js` を静的ファイル配信 (`app.send_static_file`) に変更し、`products.js` を gitignore 対象とした変更を元に戻し、Store DB から商品情報を取得して動的にレンダリングする従来の実装に戻します。

## 変更内容

- `src/app.py`: `/js/products.js` を Store DB からの動的生成（`render_template` + Cache-Control ヘッダ）に戻す
- `.gitignore`: `/src/public/javascripts/products.js` の除外を削除

リバート対象: 968eece (Merge pull request #224)

🤖 Generated with [Claude Code](https://claude.com/claude-code)