### PR TITLE
Store DB 未接続時に products.js を静的ファイルにフォールバック

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ target
 # SSL auth file
 fileauth.txt
 fileauth_*.txt
+
+# ローカル開発用の静的 products.js (本番は /js/products.js で動的生成)
+/src/javascripts/products.js

--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,7 @@ import re
 import secrets
 import subprocess
 
-from flask import Flask, make_response, render_template, request
+from flask import Flask, make_response, render_template, request, send_from_directory
 
 from src.models.verifying import Verifying
 from src.models.customer import Customer
@@ -654,6 +654,13 @@ def demo_timer():
 ########################################
 @app.route("/js/products.js")
 def products_js():
+    # ローカル開発などで Store DB に接続できない場合は、静的ファイルにフォールバックする。
+    # src/javascripts/products.js を配置しておくとそれを配信する (gitignore 対象)。
+    if not os.environ.get("MYSQL_STORE_HOST"):
+        return send_from_directory(
+            os.path.join(app.root_path, "javascripts"), "products.js"
+        )
+
     # Store DB から商品情報を取得
     # TODO: これはとりあえずの実装なのでDBへのコネクションはコネクションプールを使うなどしたい
     with get_store_db_connection() as conn:


### PR DESCRIPTION
## 概要

ローカル開発などで Store DB に接続できない環境でも `/js/products.js` を読み込めるようにしました。

`MYSQL_STORE_HOST` が未設定の場合は Store DB を参照せず、`src/javascripts/products.js` を静的ファイルとして配信するフォールバックを追加しました。本番環境（env 設定あり）は従来どおり Store DB から動的生成。

## 変更内容

- `src/app.py`: `/js/products.js` ルートに、`MYSQL_STORE_HOST` 未設定時は `src/javascripts/products.js` を `send_from_directory` で返すフォールバックを追加
- `.gitignore`: ローカル用の `src/javascripts/products.js` を除外対象に追加

## 使い方（ローカル）

`src/javascripts/products.js` に `TriboxContest.Products[id] = name` 形式のファイルを配置すると、DB なしで読み込まれます（このファイルは gitignore 対象）。