### PR TITLE
ヘッダーロゴをクリックでトップ画面に遷移するように

### DIFF
--- a/src/templates/components/bodyheader.html
+++ b/src/templates/components/bodyheader.html
@@ -2,11 +2,13 @@
 
 <div id="header">
   <div id="header-background"></div>
-  <img
-    src="/assets/images/logo-tribox-contest_222x128_white.svg"
-    alt="triboxContest"
-    id="header-logo"
-  />
+  <a href="[[ url_for('index') ]]">
+    <img
+      src="/assets/images/logo-tribox-contest_222x128_white.svg"
+      alt="triboxContest"
+      id="header-logo"
+    />
+  </a>
 </div>
 
 [% if cid == '' %]


### PR DESCRIPTION
## 概要
ヘッダーのロゴをクリックするとトップ画面（`index`）に遷移するようにしました。

## 変更内容
- `src/templates/components/bodyheader.html` のロゴ画像（`#header-logo`）を `url_for('index')` へのリンクで囲みました。