### PR TITLE
ルールボタンをクリックで/regulationsに遷移するように

### DIFF
--- a/src/templates/components/bodyheader.html
+++ b/src/templates/components/bodyheader.html
@@ -31,7 +31,7 @@
     />
     <div>トリコンとは</div></a
   >
-  <a id="main-menu-3">
+  <a href="/regulations" id="main-menu-3">
     <img
       src="/assets/images/icons/rule_book.svg"
       height="18"


### PR DESCRIPTION
## 概要
ヘッダーのルールボタンをクリックすると `/regulations` に遷移するようにしました。

## 変更内容
- `src/templates/components/bodyheader.html` のルールボタン（`#main-menu-3`）に `href="/regulations"` を追加しました。

これまでルールボタンには遷移先が設定されていませんでした。