### PR TITLE
ヘッダーメニューのハイライト判定を修正

### DIFF
--- a/src/templates/components/bodyheader.html
+++ b/src/templates/components/bodyheader.html
@@ -171,18 +171,20 @@
 
   //表示しているページに対応するmenuアイテムにclass="active"を付与する
   var currentPath = window.location.pathname;
-  if (currentPath.includes("/about")) {
+  if (currentPath === "/") {
+    document.getElementById("main-menu-1").classList.add("active");
+  } else if (currentPath.includes("/about")) {
     document.getElementById("main-menu-2").classList.add("active");
-  } else if (currentPath.includes("/rules")) {
+  } else if (currentPath.includes("/regulations")) {
     document.getElementById("main-menu-3").classList.add("active");
+  } else if (currentPath.includes("/ranking")) {
+    if (currentPath.includes("/puzzle")) {
+      document.getElementById("main-menu-6").classList.add("active");
+    } else {
+      document.getElementById("main-menu-5").classList.add("active");
+    }
   } else if (currentPath.includes("/contest")) {
     document.getElementById("main-menu-4").classList.add("active");
-  } else if (currentPath.includes("/ranking")) {
-    document.getElementById("main-menu-5").classList.add("active");
-  } else if (currentPath.includes("/puzzle")) {
-    document.getElementById("main-menu-6").classList.add("active");
-  } else {
-    document.getElementById("main-menu-1").classList.add("active");
   }
 </script>
 


### PR DESCRIPTION
## 概要
ヘッダーメニューのハイライト（active）判定を、ページごとに正しく動作するよう修正しました。

## 変更内容
- **トップページ（`/`）** → 「参加！」をハイライト。これまでは「上記以外すべて」で参加！がハイライトされていたため、トップページ限定に変更
- **`/about`** → 「トリコンとは」
- **`/regulations`** → 「ルール」。これまで `/rules` を判定しており一致しなかったバグを修正
- **`/ranking` 系** → 「ランキング」。ただし `/puzzle` を含む場合は「パズルシェア」。これまで `/ranking` が先に一致し `/puzzle` 分岐に到達しなかったため、ネストして修正
- **`/contest` 配下** → 「リザルト」
- **それ以外のページ** → どこもハイライトしない（`else` を削除）