### PR TITLE
Reserve fixed-width centered flag column to fix name alignment

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -436,6 +436,19 @@ a.contestresult-puzzle-name:hover {
   height: 48px;
 }
 
+/* 国旗は幅が国ごとに異なるため、固定幅の枠を確保して中央揃えにし、後続の名前位置がズレないようにする */
+.contestresult-table-flag {
+  flex: 0 0 32px;
+  width: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.contestresult-table-flag img {
+  max-width: 100%;
+}
+
 .contestresult-table-line-clamp {
   display: block;
   max-width: 100%;

--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -346,16 +346,6 @@ a.contestresult-puzzle-name:hover {
   color: #808080;
 }
 
-.contest-event-card-flag,
-.contest-event-card-flag-placeholder {
-  margin-left: 8px;
-}
-
-.contest-event-card-flag-placeholder {
-  display: inline-block;
-  width: 24px;
-}
-
 
 /* スクランブル */
 .contestresult-scramble-section {

--- a/src/templates/contest.html
+++ b/src/templates/contest.html
@@ -275,13 +275,13 @@ cid %]
                           <td class="contestresult-table-text-align-end" style="width:80px">{{ r.resultF }}</td>
                           <td>
                             <div class="contestresult-table-name">
-                              <img
-                                class="contest-event-card-flag"
-                                src="https://flagcdn.com/{{ r.user.iso2.toLowerCase() }}.svg"
-                                ng-show="r.user.iso2"
-                                height="16"
-                              />
-                              <span class="contest-event-card-flag-placeholder" ng-hide="r.user.iso2"></span>
+                              <div class="contestresult-table-flag">
+                                <img
+                                  src="https://flagcdn.com/{{ r.user.iso2.toLowerCase() }}.svg"
+                                  ng-show="r.user.iso2"
+                                  height="16"
+                                />
+                              </div>
                               <a
                                 class="contestresult-table-line-clamp contestresult-table-link"
                                 href="/user/{{ r.user.username }}"

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -207,11 +207,13 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                       </td>
                       <td class="contestresult-table-cell-padded">
                         <div class="contestresult-table-name">
-                          <img
-                            src="https://flagcdn.com/{{ r.user.iso2.toLowerCase() }}.svg"
-                            ng-show="r.user.iso2"
-                            height="16"
-                          />
+                          <div class="contestresult-table-flag">
+                            <img
+                              src="https://flagcdn.com/{{ r.user.iso2.toLowerCase() }}.svg"
+                              ng-show="r.user.iso2"
+                              height="16"
+                            />
+                          </div>
                           <a
                             class="contestresult-table-line-clamp contestresult-table-link"
                             href="/user/{{ r.user.username }}"


### PR DESCRIPTION
## 概要
リザルト（contestresult）の国旗は国ごとに幅が異なるため、後続の名前の表示位置がズレていました。国旗用に固定幅(32px)の枠を確保し、その中で国旗を中央揃えにすることで、どの国旗でも名前の開始位置が揃うようにしました。

## 変更内容
- `src/templates/contestresult.html`: 国旗 `<img>` を `.contestresult-table-flag` の枠で囲んだ
- `src/public/stylesheets/contestresult.css`: `.contestresult-table-flag` を追加（`width: 32px` を確保し、flexで中央揃え）。国旗が無い場合（`ng-show` で非表示）も枠は確保されるため、名前位置は常に一定

## 補足
- 横長すぎる国旗が枠からはみ出さないよう `img` に `max-width: 100%` を指定
- モバイル時の国旗高さ（12px）の既存指定はそのまま有効