### PR TITLE
Prevent puzzle brand logo from shrinking and fix its vertical centering

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -426,6 +426,15 @@ a.contestresult-puzzle-name:hover {
   height: 48px;
 }
 
+.contestresult-table-puzzle > img,
+.contestresult-table-puzzle > a:not(.contestresult-table-line-clamp) {
+  flex-shrink: 0;
+}
+
+.contestresult-table-puzzle img {
+  display: block;
+}
+
 /* 国旗は幅が国ごとに異なるため、固定幅の枠を確保して中央揃えにし、後続の名前位置がズレないようにする */
 .contestresult-table-flag {
   flex: 0 0 32px;


### PR DESCRIPTION
## 概要
リザルト（contestresult）と `/contest/<sid>`（contest）のパズル列で、パズル名が長く `...` で省略されるとメーカーロゴが潰れていました。また、ロゴが `<a>` で囲まれている database タイプのパズルでは、ロゴがやや上寄りに表示されていました。これらを修正しました。

## 変更内容
`src/public/stylesheets/contestresult.css`
- ロゴ（flex直下の `<img>`、およびロゴを囲む `<a>`）に `flex-shrink: 0` を指定し、パズル名が長くてもロゴが潰れないようにした。名前側（`.contestresult-table-line-clamp`）はこれまで通り縮んで省略される
- ロゴ `<img>` を `display: block` にし、`<a>` 内のインライン画像で生じるベースライン下余白による上寄りを解消して中央に揃えた

## 対象
- リザルト（contestresult.html）
- コンテストページ `/contest/<sid>`（contest.html）

いずれも `.contestresult-table-puzzle` を共有しているため、CSSの修正のみで両ページに反映されます。