### PR TITLE
Fix competitor/organization display order on contest result page

### DIFF
--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -218,9 +218,9 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                             class="contestresult-table-line-clamp contestresult-table-link"
                             href="/user/{{ r.user.username }}"
                           >
-                            <span ng-if="r.user.organization">
-                              {{ r.user.organization }} /
-                            </span>{{ r.user.displayname }}
+                            {{ r.user.displayname }}<span ng-if="r.user.organization">
+                              / {{ r.user.organization }}
+                            </span>
                           </a>
                         </div>
                       </td>


### PR DESCRIPTION
## 概要
リザルトページ（`/contest/result/<sid>/<cid>`、contestresult.html）で、競技者名と所属の表示順が逆になっていました。ヘッダーは「競技者 / 所属」なのに、本文は「所属 / 競技者」の順で表示されていたため、正しい順に修正しました。

## 変更内容
`src/templates/contestresult.html`
- 表示を `{{ displayname }} / {{ organization }}`（競技者 / 所属）の順に修正
- 所属が無いユーザーは従来どおり名前のみ表示

ヘッダーの「競技者 / 所属」および `/contest` ページ（contest.html）の表記順と一致します。