### PR TITLE
Add login/signup and mypage/settings/logout links to header

### DIFF
--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -61,6 +61,19 @@ h6 {
   height: 64px;
 }
 
+#header-auth {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+#header-auth a {
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: normal;
+  white-space: nowrap;
+}
+
 @media screen and (max-width: 697px) {
   #header {
     margin-bottom: 24px;

--- a/src/templates/components/authjs.html
+++ b/src/templates/components/authjs.html
@@ -18,6 +18,11 @@
         $scope.isTemporaryPassword = false;
         $scope.authLoaded = false;
 
+        $scope.logout = function() {
+            Auth.$signOut();
+            location.href = '[[ url_for("index") ]]?logout=1';
+        };
+
         Auth.$onAuthStateChanged(function(authData) {
             if (authData) {
                 angular.element(document.getElementById('auth-info')).removeClass('hide');

--- a/src/templates/components/bodyheader.html
+++ b/src/templates/components/bodyheader.html
@@ -9,6 +9,25 @@
       id="header-logo"
     />
   </a>
+  <div id="header-auth" ng-controller="AuthCtrl" ng-cloak>
+    <a href="[[ url_for('login') ]]" ng-show="authLoaded && !isLoggingin"
+      >ログイン</a
+    >
+    <a href="[[ url_for('join') ]]" ng-show="authLoaded && !isLoggingin"
+      >新規登録</a
+    >
+    <a
+      href="/user/{{ userData.username }}"
+      ng-show="authLoaded && isLoggingin"
+      >マイページ</a
+    >
+    <a href="[[ url_for('setting') ]]" ng-show="authLoaded && isLoggingin"
+      >設定</a
+    >
+    <a class="cursor-pointer" ng-click="logout()" ng-show="authLoaded && isLoggingin"
+      >ログアウト</a
+    >
+  </div>
 </div>
 
 [% if cid == '' %]


### PR DESCRIPTION
## 概要
ヘッダーにログイン・新規登録への動線が無かったため、ヘッダーバー右側にリンクを追加しました。ログイン状態に応じて表示を切り替えます。

## 変更内容
- **未ログイン時**: ログイン / 新規登録
- **ログイン時**: マイページ / 設定 / ログアウト

`src/templates/components/bodyheader.html`
- ヘッダー右側に `#header-auth` を追加。`ng-controller="AuthCtrl"` でログイン状態を取得し、`isLoggingin` で出し分け
  - マイページ: `/user/{{ userData.username }}`
  - 設定: `url_for('setting')`
  - ログアウト: `ng-click="logout()"`（即ログアウト）

`src/templates/components/authjs.html`
- `AuthCtrl` に `logout()` を追加（`Auth.$signOut()` → `index?logout=1`）。既存の `/logout` ページと同じ処理を中間ページなしで実行

`src/public/stylesheets/main.css`
- `#header-auth` のスタイル（flexで右寄せ・白の細字14px）

## 補足
- ヘッダーは `AuthCtrl` の外でレンダリングされるため、auth リンクのコンテナに `AuthCtrl` を付与しています