### PR TITLE
Restore video link and admin delete columns on contest result page

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -578,6 +578,14 @@ a.contestresult-puzzle-name:hover {
   width: 32px;
 }
 
+.contestresult-table-col-video {
+  width: 32px;
+}
+
+.contestresult-table-col-admin {
+  width: 56px;
+}
+
 .contestresult-table-show-mobile {
   display: none;
 }

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -163,6 +163,10 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         <img class="contestresult-table-show-mobile" src="/assets/images/icons/cube_empty.png" height="24" title="パズル" alt="パズル" />
                         <span class="contestresult-table-hide-mobile">パズル</span>
                       </th>
+                      <th class="contestresult-table-cell-padded contestresult-table-hide-mobile contestresult-table-col-video">
+                        <i class="fa fa-video-camera"></i>
+                      </th>
+                      <th class="contestresult-table-cell-padded contestresult-table-col-admin" ng-if="usersecretData.isAdmin">運営用</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -239,6 +243,21 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                           >{{ r.puzzleF }}</a>
                           <span class="contestresult-table-hide-mobile" ng-if="r.puzzle.type != 'database'">{{ r.puzzleF }}</span>
                         </div>
+                      </td>
+                      <td class="contestresult-table-cell-padded contestresult-table-hide-mobile">
+                        <a ng-if="r.videoUrl" href="{{ r.videoUrl | encodeURI }}" target="_blank">
+                          <i class="fa fa-video-camera"></i>
+                        </a>
+                      </td>
+                      <td class="contestresult-table-cell-padded" ng-if="usersecretData.isAdmin">
+                        <a
+                          class="btn btn-small btn-error"
+                          style="margin: 0"
+                          href="javascript:void(0);"
+                          ng-click="deleteResult(r.user.username, r.user.displayname, '/admin-api/contest/result/delete?c=[[ cid ]]&e=[[ eid ]]&u=' + r.user.username + '&token=' + usersecretData.adminToken)"
+                        >
+                          削除
+                        </a>
                       </td>
                     </tr>
                   </tbody>


### PR DESCRIPTION
## 概要
リザルトページ（`/contest/result/<sid>/<cid>`、contestresult.html）の新デザインに、旧デザインにあった以下の2機能を復元しました。

## 変更内容
`src/templates/contestresult.html`
- **動画リンク列**（パズル列の右）: ヘッダーはビデオカメラアイコン。`r.videoUrl` があればクリックでその動画リンクへ遷移（`target="_blank"`）。無ければ空セル。旧デザイン同様モバイルでは非表示
- **運営用 削除列**（最右）: `usersecretData.isAdmin`（運営アカウント）のときのみ表示。既存の `deleteResult()` を呼び、削除URLは `/admin-api/contest/result/delete?c=...&e=...&u=...&token=usersecretData.adminToken`

`src/public/stylesheets/contestresult.css`
- `table-layout: fixed` で列幅が均等配分され他列が潰れていたため、固定幅クラスを追加
  - `.contestresult-table-col-video`（32px）
  - `.contestresult-table-col-admin`（56px）

## 補足
- `deleteResult()` はコントローラに既存だったためロジック追加は不要
- 詳細展開行の colspan は `getVisibleColspan()` がヘッダーセル数を動的にカウントするため列追加でも自動対応