### PR TITLE
Show puzzle brand logo based on brand instead of user flag

### DIFF
--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -232,7 +232,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         <div class="contestresult-table-puzzle">
                           <img
                             src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
-                            ng-show="r.user.iso2"
+                            ng-show="r.puzzle.brand"
                             height="24"
                           />
                           <a


### PR DESCRIPTION
## 概要
リザルトページ（`/contest/result/<sid>/<cid>`）で、国旗が無いユーザー（`iso2` 未設定）だとパズルのメーカーロゴも表示されない不具合を修正しました。

## 原因
メーカーロゴ `<img>` の表示条件が `ng-show="r.user.iso2"`（国旗の有無）になっていたため、国旗が無いユーザーではメーカーロゴも非表示になっていました。

## 変更内容
`src/templates/contestresult.html`
- パズルメーカーロゴの表示条件を `ng-show="r.user.iso2"` → `ng-show="r.puzzle.brand"` に修正

国旗の有無に関係なく、メーカー情報があればロゴが表示されます。