### PR TITLE
Center event picker icons on contest result page

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -135,6 +135,7 @@
 .contestresult-picker-event {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   padding: 8px;
   margin-bottom: 16px;
   background-color: #fff;


### PR DESCRIPTION
## 概要
リザルトページ（`/contest/result/<sid>/<cid>`）の種目ピッカー（TOP / 3x3 / 2x2 … のアイコンバー）が左寄せになっていたため、中央揃えにしました。

## 変更内容
`src/public/stylesheets/contestresult.css`
- `.contestresult-picker-event` に `justify-content: center;` を追加

`display: flex; flex-wrap: wrap;` で `justify-content` 未指定（既定の左寄せ）だったため、アイコンが左に寄っていました。