### PR TITLE
Add gap between event picker buttons on contest result page

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -136,6 +136,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  gap: 4px;
   padding: 8px;
   margin-bottom: 16px;
   background-color: #fff;


### PR DESCRIPTION
## 概要
リザルトページ（`/contest/result/<sid>/<cid>`）の種目ピッカーの各ボタンが隣同士くっついていたため、間に余白（gap）を入れて見た目を整えました。

## 変更内容
`src/public/stylesheets/contestresult.css`
- `.contestresult-picker-event` に `gap: 4px;` を追加

各種目ボタンが少し離れ、ホバー時の背景も隣のタイルと接しなくなります。