### PR TITLE
Center puzzle stats block and sync title visibility with graph

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -213,7 +213,9 @@
 }
 
 .contestresult-puzzle-section {
-  margin-bottom: 16px;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 auto 16px;
 }
 
 .contestresult-puzzle-section-title {

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -65,8 +65,8 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                 [% import "components/contestpicker.html" as contestpicker %]
                 [[ contestpicker.print(cid=cid, eid=eid, active_event=eid) ]]
 
-                <div class="contestresult-puzzle-section">
-                  <div class="contestresult-puzzle-section-title contestresult-hide-mobile">参加者全員のパズル</div>
+                <div class="contestresult-puzzle-section" ng-if="resultsPuzzlesAll.e[[ eid ]]">
+                  <div class="contestresult-puzzle-section-title">参加者全員のパズル</div>
                   <div class="contestresult-puzzle-content">
                     <div class="contestresult-puzzle-list">
                       <div
@@ -98,8 +98,8 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                   </div>
                 </div>
 
-                <div class="contestresult-puzzle-section">
-                  <div class="contestresult-puzzle-section-title contestresult-hide-mobile">入賞者のパズル</div>
+                <div class="contestresult-puzzle-section" ng-if="resultsPuzzles.e[[ eid ]]">
+                  <div class="contestresult-puzzle-section-title">入賞者のパズル</div>
                   <div class="contestresult-puzzle-content">
                     <div class="contestresult-puzzle-list">
                       <div


### PR DESCRIPTION
## 概要
リザルトページ（`/contest/result/<sid>/<cid>`）のパズル使用率（「参加者全員のパズル」「入賞者のパズル」）まわりの表示を改善しました。

## 変更内容
`src/public/stylesheets/contestresult.css`
- `.contestresult-puzzle-section` を `width: fit-content; max-width: 100%; margin: 0 auto;` にし、見出し＋グラフを1つの塊として中央寄せ。幅は一番長いパズル名の長さに応じて変わる（固定幅をやめた）

`src/templates/contestresult.html`
- 見出しから `contestresult-hide-mobile` を削除し、スマホでも「参加者全員のパズル」「入賞者のパズル」が表示されるように
- 各セクションに `ng-if`（`resultsPuzzlesAll.e<eid>` / `resultsPuzzles.e<eid>`）を付与し、パズルデータが揃ってから見出しとグラフが同時に表示されるように（データ取得前に見出しだけ先に出る不自然さを解消）