### PR TITLE
Auto-scroll season carousel to center the active contest on load

### DIFF
--- a/src/templates/components/contestpickerjs.html
+++ b/src/templates/components/contestpickerjs.html
@@ -30,6 +30,20 @@
         $scope.eventFullNames = eventFullNames;
         $scope.eventIcons = eventIcons;
       },
+      scrollActiveContestIntoCenter: function() {
+        function tryScroll(attempts) {
+          var container = document.querySelector(".contestresult-picker-contest");
+          var active = container && container.querySelector(".contestresult-picker-contest-item.active");
+          if (container && active && container.offsetParent !== null) {
+            var cRect = container.getBoundingClientRect();
+            var aRect = active.getBoundingClientRect();
+            container.scrollLeft += (aRect.left - cRect.left) - (container.clientWidth - active.clientWidth) / 2;
+          } else if (attempts > 0) {
+            requestAnimationFrame(function() { tryScroll(attempts - 1); });
+          }
+        }
+        tryScroll(60);
+      },
       loadSeasons: function($scope, contestRef, cid, callback) {
         var currentSeason = cid.slice(0, 5);
         contestRef.child("contests").once("value", function(snapContests) {
@@ -68,6 +82,7 @@
             $scope.currentContestNumber = parseInt(cid.slice(5), 10);
             $scope.contestsList = _contestsList;
             if (callback) callback();
+            ContestPicker.scrollActiveContestIntoCenter();
           });
         });
       }


### PR DESCRIPTION
## 概要
各種目の詳細画面（リザルト／コンテストページ）のシーズン（節）選択カルーセルで、ページを開いたときに選択中の節の数字ができるだけ中央に表示されるよう、自動スクロールを追加しました。

## 変更内容
`src/templates/components/contestpickerjs.html`
- `ContestPicker.scrollActiveContestIntoCenter()` を追加し、`loadSeasons` 完了時に呼び出し
- 選択中の節（`.contestresult-picker-contest-item.active`）が、スクロールコンテナ（`.contestresult-picker-contest`）の中央に来るよう `scrollLeft` を調整

## 補足
- `requestAnimationFrame` でリトライし、`offsetParent !== null` で要素が表示されてからスクロール（`main-content` が `ng-show` で初期非表示のため）
- `getBoundingClientRect` で位置計算しているため、配置（position）に依存せず正確に中央寄せ
- 共有コンポーネントのため、リザルトページ（contestresult）と `/contest/<sid>`（contest）の両方に反映されます