### PR TITLE
Add moves column to FMC result page

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -574,6 +574,10 @@ a.contestresult-puzzle-name:hover {
   width: 96px;
 }
 
+.contestresult-table-col-moves {
+  width: 64px;
+}
+
 .contestresult-table-col-deploy {
   width: 32px;
 }

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -142,6 +142,8 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                       <th class="contestresult-table-text-align-end contestresult-table-col-place">順位</th>
                       [% if eid != "333fm" %]
                       <th class="contestresult-table-text-align-end contestresult-table-col-avg">Avg. of 5</th>
+                      [% else %]
+                      <th class="contestresult-table-text-align-center contestresult-table-col-moves">手数</th>
                       [% endif %]
                       <th class="[% if eid == '333fm' %]contestresult-table-col-detail-body[% else %]contestresult-table-col-deploy[% endif %]">
                         [% if eid != "333fm" %]
@@ -187,9 +189,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         </div>
                       </td>
                       <td class="contestresult-table-text-align-end">{{ r.place }}位</td>
-                      [% if eid != "333fm" %]
-                      <td class="contestresult-table-text-align-end contestresult-table-font-bold">{{ r.resultF }}</td>
-                      [% endif %]
+                      <td class="[% if eid == '333fm' %]contestresult-table-text-align-center[% else %]contestresult-table-text-align-end[% endif %] contestresult-table-font-bold">{{ r.resultF }}</td>
                       <td class="[% if eid == '333fm' %]contestresult-table-col-detail-body[% else %]contestresult-table-col-deploy-body[% endif %]">
                         [% if eid == "333fm" %]
                         <div class="contestresult-table-deploy-button-container">


### PR DESCRIPTION
## 概要
FMC（333fm）のリザルト画面で手数が表示されていなかったため、順位の右隣に「手数」カラムを追加しました。

## 変更内容
`src/templates/contestresult.html`
- ヘッダー: 順位の右に、非FMCは「Avg. of 5」、FMCは「手数」を表示（`eid` で出し分け）
- 値は `{{ r.resultF }}`（`TriboxContest.formatResult` で全種目分生成され、FMCでは手数）。FMCで省いていた条件分岐を撤去し常に表示
- 手数列は中央揃え（非FMCのAvgは従来どおり右寄せ）

`src/public/stylesheets/contestresult.css`
- 手数列用の幅クラス `.contestresult-table-col-moves`（64px）を追加（Avg列の96px流用だと広すぎたため）

## 補足
- 詳細展開行の colspan は `getVisibleColspan()` がヘッダー数を動的カウントするため列追加でも自動対応