### PR TITLE
Show video column on mobile in contest result table

### DIFF
--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -165,7 +165,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         <img class="contestresult-table-show-mobile" src="/assets/images/icons/cube_empty.png" height="24" title="パズル" alt="パズル" />
                         <span class="contestresult-table-hide-mobile">パズル</span>
                       </th>
-                      <th class="contestresult-table-cell-padded contestresult-table-hide-mobile contestresult-table-col-video">
+                      <th class="contestresult-table-cell-padded contestresult-table-col-video">
                         <i class="fa fa-video-camera"></i>
                       </th>
                       <th class="contestresult-table-cell-padded contestresult-table-col-admin" ng-if="usersecretData.isAdmin">運営用</th>
@@ -244,7 +244,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                           <span class="contestresult-table-hide-mobile" ng-if="r.puzzle.type != 'database'">{{ r.puzzleF }}</span>
                         </div>
                       </td>
-                      <td class="contestresult-table-cell-padded contestresult-table-hide-mobile">
+                      <td class="contestresult-table-cell-padded">
                         <a ng-if="r.videoUrl" href="{{ r.videoUrl | encodeURI }}" target="_blank">
                           <i class="fa fa-video-camera"></i>
                         </a>


### PR DESCRIPTION
## 概要
リザルトページ（`/contest/result/<sid>/<cid>`）の動画列がスマホ画面で非表示になっていたため、表示されるようにしました。

## 変更内容
`src/templates/contestresult.html`
- 動画列の `<th>` / `<td>` から `contestresult-table-hide-mobile` を削除し、モバイルでも動画リンク列を表示