### PR TITLE
Label result column as Mean of 3 for 6x6 and 7x7

### DIFF
--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -140,10 +140,12 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                     <tr>
                       <th class="contestresult-table-text-align-center contestresult-table-col-sp contestresult-table-hide-mobile">SP</th>
                       <th class="contestresult-table-text-align-end contestresult-table-col-place">順位</th>
-                      [% if eid != "333fm" %]
-                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Avg. of 5</th>
-                      [% else %]
+                      [% if eid == "333fm" %]
                       <th class="contestresult-table-text-align-center contestresult-table-col-moves">手数</th>
+                      [% elif eid == "666" or eid == "777" %]
+                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Mean of 3</th>
+                      [% else %]
+                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Avg. of 5</th>
                       [% endif %]
                       <th class="[% if eid == '333fm' %]contestresult-table-col-detail-body[% else %]contestresult-table-col-deploy[% endif %]">
                         [% if eid != "333fm" %]


### PR DESCRIPTION
## 概要
6x6 と 7x7 のリザルトは集計が mean of 3 のため、結果列のヘッダーを「Avg. of 5」から「Mean of 3」に変更しました。

## 変更内容
`src/templates/contestresult.html`
- 結果列ヘッダーを種目で出し分け：
  - FMC（333fm）: 手数
  - 6x6（666）/ 7x7（777）: Mean of 3
  - それ以外: Avg. of 5
- 値（`{{ r.resultF }}`）は `TriboxContest.formatResult` が種目ごとに算出するため、変更はヘッダーのラベルのみ