### PR TITLE
Fix blank record cells for results with duplicate solve values

### DIFF
--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -208,7 +208,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                       </td>
                       <td class="contestresult-table-detail-records contestresult-table-cell-padded">
                         <div class="contestresult-table-records">
-                          <div class="contestresult-table-record-items" ng-repeat="d in r.detailsF.split(' ')">{{ d }}</div>
+                          <div class="contestresult-table-record-items" ng-repeat="d in r.detailsF.split(' ') track by $index">{{ d }}</div>
                         </div>
                       </td>
                       <td class="contestresult-table-cell-padded">


### PR DESCRIPTION
## 概要
リザルトページ（`/contest/result/<sid>/<cid>`）で、目隠し（333bf）などで **DNFが2つ以上ある人（＝同じ値が重複する人）の「個々の記録」が空白**になっていた不具合を修正しました。

## 原因
個々の記録は以下で描画していました：
```html
<div class="contestresult-table-record-items" ng-repeat="d in r.detailsF.split(' ')">{{ d }}</div>
```
AngularJS の `ng-repeat` は `track by` 無しだと**重複した値があるとエラー（ngRepeat:dupes）**になり、その行を一切描画しません。

- 2DNF以上の人: 例 `["DNF","DNF","37.614"]` → "DNF" が重複 → エラーで空白
- 全DNFの人: `["DNF","DNF","DNF"]` → 同様に空白
- 重複しない人（0〜1DNF等）: 正常表示

データ・整形（`detailsF`）自体は全員正しく、表示側だけの問題でした。

## 変更内容
`src/templates/contestresult.html`
- `ng-repeat="d in r.detailsF.split(' ')"` に `track by $index` を追加し、重複値があっても全ソルブを描画するように修正