### PR TITLE
Add floating scramble bar on FMC result page

### DIFF
--- a/src/public/javascripts/contestresult.js
+++ b/src/public/javascripts/contestresult.js
@@ -19,6 +19,18 @@ if (headButton) {
   });
 }
 
+// フローティングのスクランブル: 元のスクランブルが見えたら (最下部) 非表示にする
+var inflowScramble = document.querySelector('.contestresult-scramble-section:not(.contestresult-scramble-section-floating)');
+var floatingScramble = document.querySelector('.contestresult-scramble-section-floating');
+if (inflowScramble && floatingScramble && 'IntersectionObserver' in window) {
+  var scrambleObserver = new IntersectionObserver(function(entries) {
+    entries.forEach(function(entry) {
+      floatingScramble.classList.toggle('contestresult-scramble-hidden', entry.isIntersecting);
+    });
+  });
+  scrambleObserver.observe(inflowScramble);
+}
+
 // tbody の detail ボタン (333fm): アイコン切り替え
 document.querySelectorAll('tbody .contestresult-table-deploy-button').forEach(function(button) {
   button.addEventListener('click', function() {

--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -357,6 +357,31 @@ a.contestresult-puzzle-name:hover {
   margin-bottom: 16px;
 }
 
+.contestresult-scramble-section-floating {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 16px;
+  z-index: 100;
+  width: calc(100% - 32px);
+  max-width: 1150px;
+  margin: 0;
+  padding: 12px 16px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+  max-height: 40vh;
+  overflow-y: auto;
+  transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s;
+}
+
+.contestresult-scramble-section-floating.contestresult-scramble-hidden {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%) translateY(20px);
+  pointer-events: none;
+}
+
 .contestresult-scramble-title {
   font-size: 16px;
   font-weight: bold;

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -280,6 +280,23 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                   </table>
                 </div>
 
+                [% if eid == "333fm" %]
+                <div class="contestresult-scramble-section contestresult-scramble-section-floating">
+                  <div class="contestresult-scramble-title">スクランブル</div>
+                  <table class="contestresult-scramble-table">
+                    <tbody>
+                      <tr
+                        class="contestresult-scramble-item"
+                        ng-repeat="s in scramblesData.e[[ eid ]]"
+                      >
+                        <td class="contestresult-scramble-number">{{ $index + 1 }}</td>
+                        <td class="contestresult-scramble-text" ng-bind-html="s"></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                [% endif %]
+
                 [#
                 <!--<p>usersecretData:</p>
                 <pre>{{ usersecretData | json }}</pre>-->


### PR DESCRIPTION
## 概要
FMC（333fm）のリザルトページで、スクランブルを画面下部に常時表示するフローティングバーを追加しました。最下部までスクロールして元のスクランブル表示が見えると、フローティングはフェードして非表示になります。

## 変更内容
`src/templates/contestresult.html`
- 元の（流れの中の）スクランブル表示はそのまま維持
- FMCのときのみ、同じ内容のフローティング版スクランブルを追加

`src/public/stylesheets/contestresult.css`
- `.contestresult-scramble-section-floating`: 画面下部に `position: fixed` で配置。中央寄せ＋`max-width: 1150px`（PCで広がりすぎないようコンテンツ幅に合わせる）、角丸・影、`max-height: 40vh` でスクロール可
- 非表示クラスは `opacity` / `visibility` / `transform` で制御し、`transition` でフェード＋スライド

`src/public/javascripts/contestresult.js`
- `IntersectionObserver` で、元のスクランブルが画面内に入ったら（＝最下部までスクロール時）フローティングを非表示、離れたら再表示

## 補足
- FMC以外の種目は従来どおり通常のスクランブル表示のみ