### PR TITLE
Redesign footer to match about.tribox.com and make it sticky

### DIFF
--- a/src/public/images/icons/company_gray90.svg
+++ b/src/public/images/icons/company_gray90.svg
@@ -1,0 +1,5 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 15.75V2.25H3V15.75" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 9.75H6V15.75H12V9.75Z" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 9.75V15.75" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/public/images/icons/contest_gray90.svg
+++ b/src/public/images/icons/contest_gray90.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.75 1.25H4.25V6.5C4.25 8.6 5.9 10.25 8 10.25C10.1 10.25 11.75 8.6 11.75 6.5V1.25Z" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 10.25V14.75" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.25 8C2.6 8 1.25 6.65 1.25 5V2.75H3.5" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.75 8C13.4 8 14.75 6.65 14.75 5V2.75H12.5" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 14.75H11" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/public/images/icons/store_gray90.svg
+++ b/src/public/images/icons/store_gray90.svg
@@ -1,0 +1,5 @@
+<svg width="14" height="17" viewBox="0 0 14 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 15.75H1L1.75 4.5H12.25L13 15.75Z" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 4.5C4 2.85 5.35 1.5 7 1.5C8.65 1.5 10 2.85 10 4.5" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 6.75C4 8.4 5.35 9.75 7 9.75C8.65 9.75 10 8.4 10 6.75" stroke="#E6E6E6" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -178,9 +178,91 @@ h6 {
 /**
  * Footer
  */
+body > .container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 #footer {
+  position: relative;
+  margin-top: auto;
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+  color: #e6e6e6;
   font-size: 14px;
-  text-align: center;
+}
+
+#footer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100vw;
+  background: #808080;
+  z-index: -1;
+}
+
+#footer-inner {
+  width: 100%;
+  max-width: 928px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+}
+
+#footer-nav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.footer-nav-item {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  color: #e6e6e6;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.footer-nav-icon {
+  height: 18px;
+  width: 18px;
+}
+
+.footer-nav-item:hover {
+  color: #e6e6e6;
+  opacity: 0.85;
+}
+
+.footer-nav-bar {
+  position: absolute;
+  left: 0;
+  bottom: -8px;
+  width: 100%;
+  height: 2px;
+  border-radius: 1px;
+  background: #e6e6e6;
+}
+
+#footer-copyright {
+  margin: 0;
+  text-align: right;
+}
+
+#footer-copyright a {
+  color: #e6e6e6;
+  text-decoration: underline;
 }
 
 /**

--- a/src/templates/components/bodyfooter.html
+++ b/src/templates/components/bodyfooter.html
@@ -1,6 +1,20 @@
-<hr id="footer-line">
-<p id="footer">
-    [[ contest_name ]]<br>
-    Copyright &copy; 2016&ndash;2026 <a href="https://tribox.com/">Tribox Inc.</a> All Rights Reserved.<br>
-    <a href="https://github.com/tribox/tribox-contest">This software is distributed in the Apache License 2.0.</a>
-</p>
+<footer id="footer">
+  <div id="footer-inner">
+    <nav id="footer-nav">
+      <a class="footer-nav-item" href="https://store.tribox.com/" target="_blank" rel="noreferrer">
+        <img class="footer-nav-icon" src="/assets/images/icons/store_gray90.svg" alt="store icon" /><span>ストア</span>
+      </a>
+      <a class="footer-nav-item active" href="[[ url_for('index') ]]">
+        <img class="footer-nav-icon" src="/assets/images/icons/contest_gray90.svg" alt="contest icon" /><span>コンテスト</span>
+        <span class="footer-nav-bar"></span>
+      </a>
+      <a class="footer-nav-item" href="https://about.tribox.com/" target="_blank" rel="noreferrer">
+        <img class="footer-nav-icon" src="/assets/images/icons/company_gray90.svg" alt="company icon" /><span>カンパニー</span>
+      </a>
+    </nav>
+    <p id="footer-copyright">
+      Copyright &copy; 2016&ndash;2026 <a href="https://about.tribox.com/">Tribox Inc.</a> All Rights Reserved.<br />
+      <a href="https://github.com/tribox/tribox-contest">This software is distributed in the Apache License 2.0.</a>
+    </p>
+  </div>
+</footer>


### PR DESCRIPTION
## 概要
フッターを about.tribox.com と同じデザインに刷新し、あわせてローディング中などに上に来ないようスティッキーフッター化しました。

## 変更内容
`src/templates/components/bodyfooter.html`
- グレー帯（#808080）のフッターに刷新。左：ナビ（ストア / コンテスト / カンパニー、各アイコン付き）、右：コピーライト
- 「コンテスト」は現在地のため、テキスト下に角丸インジケーターバーを表示
- リンク: ストア=store.tribox.com / コンテスト=本サイト / カンパニー=about.tribox.com
- コピーライトは元の文言を維持: 「Copyright © 2016–2026 Tribox Inc. All Rights Reserved.」+「This software is distributed in the Apache License 2.0.」（Tribox Inc.→about.tribox.com、Apache行→GitHubリポジトリ）

`src/public/images/icons/{store,contest,company}_gray90.svg`
- about.tribox.com の footer アイコン（gray90）を取り込み

`src/public/stylesheets/main.css`
- スティッキーフッター: `body > .container` を `min-height: 100vh; flex column`、`#footer { margin-top: auto }`
- 全幅グレー帯（`#footer::before` の 100vw + #808080）、内側は max-width 928px・space-between
- 文字色 #E6E6E6 / font-weight 600 / アイコン 18px / アクティブの角丸バー / コピーライト右揃え（about の実CSSに準拠）

## 補足
- about の実装に合わせて値（色・高さ64px・幅928px・アイコン18px・バー）を確認して反映