### PR TITLE
Show only the current attempt's scramble on the timer page

### DIFF
--- a/src/templates/contesttimeform.html
+++ b/src/templates/contesttimeform.html
@@ -30,7 +30,6 @@
     </div>
 
 [% else %]
-    {# 試技数が3の場合 (例えば、best of 3) #}
     <div id="timeforms" class="row">
         <div class="col md-3"></div>
         <div class="col md-2 timeform-wrap" ng-repeat="i in range(3)">

--- a/src/templates/contesttimer.html
+++ b/src/templates/contesttimer.html
@@ -76,7 +76,7 @@
         <div id="touchArea">
 
             [% import "/contestscrambles.html" as contestscrambles %]
-            [[ contestscrambles.print(eid=eid) ]]
+            [[ contestscrambles.print(eid=eid, showIndividual=True) ]]
 
             <div id="timerArea">
                 <div id="timerText">0.000</div>


### PR DESCRIPTION
## 概要
競技画面（`/contest/<cid>/<eid>/timer`）で全スクランブルが表示されてしまっていたのを、現在の試技のスクランブルだけ表示するように修正しました（1試技目→1番目、2試技目→2番目…）。

## 原因
`contestscrambles.print(eid=eid)` を `showIndividual` 無し（=False）で呼んでおり、全スクランブルを `hide` 無しで並べる分岐がレンダリングされていました。タイマー画面のJSは元々 `showScramble()` で現在の試技だけ表示する設計（デモタイマーは `showIndividual=true`）。

## 変更内容
`src/templates/contesttimer.html`
- `contestscrambles.print(eid=eid, showIndividual=True)` に変更。各行が `hide` 付きでレンダリングされ、`showScramble()` が現在の試技のみ表示。ヘッダーも「1st Scramble:」のように現在の試技番号を表示

`src/templates/contesttimeform.html`
- 画面に文字列として出ていた誤ったコメント `{# ... #}`（このプロジェクトのコメント構文は `[# ... #]`）の行を削除