### PR TITLE
Hide menu on demo timer page

### DIFF
--- a/src/templates/contesttimerdemo.html
+++ b/src/templates/contesttimerdemo.html
@@ -30,7 +30,7 @@
   <body>
     <div class="container">
       [% import "components/bodyheader.html" as bodyheader %] [[
-      bodyheader.print(title=title, contest_name=contest_name) ]]
+      bodyheader.print(title=title, contest_name=contest_name, cid="demo") ]]
 
       <div ng-controller="AuthCtrl">
         <div ng-controller="ContestCtrl">


### PR DESCRIPTION
## 概要
デモタイマー画面（`/demo/timer`）でメインメニューが表示されていたので、非表示にしました。

## 変更内容
`src/templates/contesttimerdemo.html`
- `bodyheader.print(...)` に `cid="demo"` を渡すように変更

bodyheader は `cid == ''` のときのみメニューを表示する作りのため、`cid` を非空にすることでメニューが出ず、実タイマー画面と同じ表示になります。