### PR TITLE
Set logged-in user info text color to gray

### DIFF
--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -268,6 +268,10 @@ body > .container {
 /**
  * Auth Info
  */
+#auth-info {
+  color: #808080;
+}
+
 a.underlined {
   color: #e74c3c;
   text-decoration: underline;


### PR DESCRIPTION
## 概要
ログイン時に画面左上に表示されるユーザー名・所属（`#auth-info`）の文字色を `#808080` にしました。

## 変更内容
`src/public/stylesheets/main.css`
- `#auth-info { color: #808080; }` を追加

一時パスワード警告の赤文字（`.color-error`）は要素に直接色指定があるため、引き続き赤で表示されます。