### PR TITLE
Redesign login page

### DIFF
--- a/src/public/stylesheets/login.css
+++ b/src/public/stylesheets/login.css
@@ -1,0 +1,101 @@
+.auth-page {
+  display: flex;
+  justify-content: center;
+  padding: 16px 0 48px;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 400px;
+  padding: 32px;
+  background: #ffffff;
+  border-radius: 12px;
+  border: 1px solid #dddddd;
+}
+
+.auth-title {
+  font-size: 22px;
+  font-weight: bold;
+  color: #808080;
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.auth-field {
+  margin-bottom: 16px;
+}
+
+.auth-label {
+  display: block;
+  font-size: 13px;
+  font-weight: bold;
+  color: #808080;
+  margin-bottom: 4px;
+}
+
+.auth-input {
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  font-size: 14px;
+  border: 1px solid #dddddd;
+  border-radius: 8px;
+  transition: border-color 0.2s ease;
+}
+
+.auth-input:focus {
+  border-color: #0096af;
+  outline: none;
+}
+
+.auth-submit {
+  width: 100%;
+  margin-top: 8px;
+  padding: 12px;
+  border: none;
+  border-radius: 8px;
+  background: linear-gradient(-15deg, #009678, #0096af);
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.auth-submit:hover {
+  opacity: 0.92;
+}
+
+.auth-notice {
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
+.auth-notice-success {
+  background: #e8f7f3;
+  color: #1bbc9b;
+}
+
+.auth-notice-error {
+  background: #fdecea;
+  color: #e74c3c;
+}
+
+.auth-links {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 20px;
+  text-align: center;
+}
+
+.auth-links a {
+  color: #0088cc;
+  font-size: 13px;
+}
+
+.auth-links a:hover {
+  color: #006699;
+}

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -13,6 +13,12 @@
     "components/authjs.html" as authjs %] [[ authjs.print(redirect_login="",
     redirect_logout="", check_first=False) ]]
 
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="[[ url_for('static', filename='stylesheets/login.css') ]]"
+    />
+
     <script>
       app.controller("AuthLoginCtrl", [
         "$scope",
@@ -102,43 +108,35 @@
             <span class="sr-only">Loading...</span>
             Loading...
           </div>
-          <div ng-show="authLoaded">
-            <h2>ログイン</h2>
+          <div ng-show="authLoaded" class="auth-page">
+            <div class="auth-card">
+              <h2 class="auth-title">ログイン</h2>
 
-            [# <!--<div class="color-dark margin-bottom-20" ng-if="message">
-                Message: {{ message }}
-            </div>--> #]
-
-            <div class="notice-success margin-bottom-20" ng-if="afterJoin">
-              <i class="fa fa-check"></i>
-              新規ユーザ登録が完了しました。ログインしてください。
-            </div>
-            <div class="color-error margin-bottom-20" ng-if="error">
-              エラー: {{ error }}
-            </div>
-
-            <form name="loginForm" ng-submit="login()">
-              <div>
-                <label>メールアドレス</label>
-                <input class="form-control" type="email" ng-model="email" />
+              <div class="auth-notice auth-notice-success" ng-if="afterJoin">
+                <i class="fa fa-check"></i>
+                新規ユーザ登録が完了しました。ログインしてください。
               </div>
-              <div>
-                <label>パスワード</label>
-                <input
-                  class="form-control"
-                  type="password"
-                  ng-model="password"
-                />
+              <div class="auth-notice auth-notice-error" ng-if="error">
+                エラー: {{ error }}
               </div>
-              <input class="btn" type="submit" value="ログイン" />
-            </form>
 
-            <p>
-              <a href="/forgot">パスワードを忘れましたか？</a>
-            </p>
-            <p>
-              <a href="[[ url_for('join') ]]">アカウントを新規作成する</a>
-            </p>
+              <form name="loginForm" ng-submit="login()">
+                <div class="auth-field">
+                  <label class="auth-label">メールアドレス</label>
+                  <input class="auth-input" type="email" ng-model="email" />
+                </div>
+                <div class="auth-field">
+                  <label class="auth-label">パスワード</label>
+                  <input class="auth-input" type="password" ng-model="password" />
+                </div>
+                <button class="auth-submit" type="submit">ログイン</button>
+              </form>
+
+              <div class="auth-links">
+                <a href="/forgot">パスワードを忘れましたか？</a>
+                <a href="[[ url_for('join') ]]">アカウントを新規作成する</a>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要
ログインページ（`/login`）を新デザインに刷新しました。

## 変更内容
`src/public/stylesheets/login.css`（新規）
- 中央寄せのカード（白・角丸12px・1pxの枠線、max-width 400px）
- ラベル付き入力欄（フォーカスでティール枠）、ティールグラデのログインボタン
- 成功/エラーの通知ボックス、下部にリンク（パスワード忘れ／新規作成）

`src/templates/login.html`
- フォームを `.auth-card` 内にカード化し、`btn` / `form-control` を新クラス（`auth-*`）に置き換え
- 送信ボタンを `<button class="auth-submit">` に
- ログイン処理・バインディング（`login()`、`email`/`password`、`afterJoin`/`error`）は変更なし

<img width="1800" height="1041" alt="Screenshot 2026-06-21 at 23 56 32" src="https://github.com/user-attachments/assets/9166e78b-720d-48c1-b0e3-29109b53ef65" />
