### PR TITLE
Redesign join page

### DIFF
--- a/src/public/stylesheets/login.css
+++ b/src/public/stylesheets/login.css
@@ -21,6 +21,17 @@
   margin-bottom: 24px;
 }
 
+.auth-desc {
+  font-size: 13px;
+  color: #808080;
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+
+.auth-desc a {
+  color: #0088cc;
+}
+
 .auth-field {
   margin-bottom: 16px;
 }

--- a/src/templates/join.html
+++ b/src/templates/join.html
@@ -27,6 +27,13 @@
     firebaseapp_contest_senderid, firebaseapp_wca) ]] [% import
     "components/authjs.html" as authjs %] [[ authjs.print(redirect_login="",
     redirect_logout="", check_first=True) ]]
+
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="[[ url_for('static', filename='stylesheets/login.css') ]]"
+    />
+
     <script>
       app.controller("AuthJoinCtrl", [
         "$scope",
@@ -74,50 +81,36 @@
             <span class="sr-only">Loading...</span>
             Loading...
           </div>
-          <div ng-show="authLoaded">
-            <h2>新規ユーザ登録</h2>
+          <div ng-show="authLoaded" class="auth-page">
+            <div class="auth-card">
+              <h2 class="auth-title">新規ユーザ登録</h2>
 
-            <div class="notice-success margin-bottom-20" ng-if="joinMessage">
-              <i class="fa fa-check"></i>
-              {{ joinMessage }}
-            </div>
-            <div class="color-error margin-bottom-20" ng-if="error">
-              エラー: {{ error }}
-            </div>
-
-            <p>
-              メールアドレスとパスワードを入力してください。<br />
-              すでにアカウントを作成済みの場合は、<a
-                href="[[ url_for('login') ]]"
-                >ログインページ</a
-              >からログインしてください。<br />
-              hotmailでは確認メールが受信できない場合があります。
-            </p>
-
-            <form name="joinForm" ng-submit="createUser()">
-              <div>
-                <label>メールアドレス</label>
-                <input
-                  class="form-control"
-                  type="email"
-                  name="email"
-                  ng-model="email"
-                />
+              <div class="auth-notice auth-notice-success" ng-if="joinMessage">
+                <i class="fa fa-check"></i>
+                {{ joinMessage }}
+              </div>
+              <div class="auth-notice auth-notice-error" ng-if="error">
+                エラー: {{ error }}
               </div>
 
-              <!--<span ng-show="joinForm.email.$error.email">Not valid email!</span>
-            <span ng-show="joinForm.email.$error.required">Required!</span><br>-->
+              <p class="auth-desc">
+                メールアドレスとパスワードを入力してください。<br />
+                すでにアカウントを作成済みの場合は、<a href="[[ url_for('login') ]]">ログインページ</a>からログインしてください。<br />
+                hotmailでは確認メールが受信できない場合があります。
+              </p>
 
-              <div>
-                <label>パスワード</label>
-                <input
-                  class="form-control"
-                  type="password"
-                  ng-model="password"
-                />
-              </div>
-              <input class="btn" type="submit" value="登録" />
-            </form>
+              <form name="joinForm" ng-submit="createUser()">
+                <div class="auth-field">
+                  <label class="auth-label">メールアドレス</label>
+                  <input class="auth-input" type="email" name="email" ng-model="email" />
+                </div>
+                <div class="auth-field">
+                  <label class="auth-label">パスワード</label>
+                  <input class="auth-input" type="password" ng-model="password" />
+                </div>
+                <button class="auth-submit" type="submit">登録</button>
+              </form>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要
新規ユーザ登録ページ（`/join`）を、ログインページと同じ新デザインに刷新しました。

## 変更内容
`src/templates/join.html`
- フォームを `.auth-card` 内にカード化（ログインと共通の `auth-*` クラスを使用）
- `btn` / `form-control` を `auth-*` に置き換え、送信ボタンをティールグラデの `<button class="auth-submit">` に
- 説明文を `.auth-desc` で表示
- 登録処理・バインディング（`createUser()`、`email`/`password`、`joinMessage`/`error`）は変更なし

`src/public/stylesheets/login.css`
- 説明文用の `.auth-desc` を追加（join と共通の認証スタイルとして login.css を再利用）

<img width="1800" height="1043" alt="Screenshot 2026-06-22 at 0 00 54" src="https://github.com/user-attachments/assets/66cf4a5e-2e99-48a0-9669-a796a0fe4c5d" />
