### PR TITLE
Redesign logout page

### DIFF
--- a/src/templates/logout.html
+++ b/src/templates/logout.html
@@ -13,6 +13,12 @@
     "components/authjs.html" as authjs %] [[ authjs.print(redirect_login="",
     redirect_logout="", check_first=False) ]]
 
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="[[ url_for('static', filename='stylesheets/login.css') ]]"
+    />
+
     <script>
       app.controller("AuthLogoutCtrl", [
         "$scope",
@@ -42,11 +48,15 @@
             [% import "components/authinfo.html" as authinfo %] [[
             authinfo.print() ]]
 
-            <h2>ログアウト</h2>
-
-            <form name="logoutForm" ng-submit="logout()">
-              <input class="btn" type="submit" value="ログアウト" />
-            </form>
+            <div class="auth-page">
+              <div class="auth-card">
+                <h2 class="auth-title">ログアウト</h2>
+                <p class="auth-desc">ログアウトしますか？</p>
+                <form name="logoutForm" ng-submit="logout()">
+                  <button class="auth-submit" type="submit">ログアウト</button>
+                </form>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要
ログアウト画面（`/logout`）を、ログイン/新規登録と同じ認証カードデザインに統一しました。

## 変更内容
`src/templates/logout.html`
- `login.css` を読み込み、`.auth-card` 内に「ログアウト」タイトル＋確認文＋ティールグラデのログアウトボタンを配置
- ログイン中ユーザー情報（authinfo）はカードの上に表示
- ログアウト処理（`logout()`）は変更なし

<img width="1800" height="1042" alt="Screenshot 2026-06-22 at 0 07 20" src="https://github.com/user-attachments/assets/220b8d31-107a-4ae6-acea-fb662e0890e6" />
