### PR TITLE
Center puzzle stats sections together for aligned edges

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -212,10 +212,14 @@
   box-sizing: content-box;
 }
 
-.contestresult-puzzle-section {
+.contestresult-puzzle-sections {
   width: fit-content;
   max-width: 100%;
-  margin: 0 auto 16px;
+  margin: 0 auto;
+}
+
+.contestresult-puzzle-section {
+  margin-bottom: 16px;
 }
 
 .contestresult-puzzle-section-title {

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -65,6 +65,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                 [% import "components/contestpicker.html" as contestpicker %]
                 [[ contestpicker.print(cid=cid, eid=eid, active_event=eid) ]]
 
+                <div class="contestresult-puzzle-sections">
                 <div class="contestresult-puzzle-section" ng-if="resultsPuzzlesAll.e[[ eid ]]">
                   <div class="contestresult-puzzle-section-title">参加者全員のパズル</div>
                   <div class="contestresult-puzzle-content">
@@ -129,6 +130,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                       </div>
                     </div>
                   </div>
+                </div>
                 </div>
 
                 <!-- <h4>コンテスト結果</h4>


### PR DESCRIPTION
## 概要
リザルトページのパズル使用率で、「参加者全員のパズル」と「入賞者のパズル」がそれぞれ独立に中央寄せされており、使われているパズル名の長さが違うと左右がズレていました。両セクションをまとめて中央寄せにし、幅と端を揃えました。

## 変更内容
`src/templates/contestresult.html`
- 2つの `.contestresult-puzzle-section` を共通ラッパー `.contestresult-puzzle-sections` で囲んだ

`src/public/stylesheets/contestresult.css`
- 中央寄せ（`width: fit-content; max-width: 100%; margin: 0 auto`）をラッパー側に移動
- `.contestresult-puzzle-section` は `margin-bottom` のみとし、ラッパー幅（= 2セクションのうち広い方）に揃うように

これで両セクションの左右端が揃い、まとめて中央に配置されます。