### PR TITLE
Add contest form route and fix form page rendering

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -156,6 +156,23 @@ def contestchoose(cid, eid):
         firebaseapp_wca_senderid=FIREBASEAPP_WCA_SENDERID,
     )
 
+@app.route("/contest/<cid>/<eid>/form")
+def contestform(cid, eid):
+    return render_template(
+        "contestform.html",
+        cid=cid,
+        eid=eid,
+        contest_description=CONTEST_DESCRIPTION,
+        contest_name=CONTEST_NAME,
+        contest_url=CONTEST_URL,
+        firebaseapp_contest=FIREBASEAPP_CONTEST,
+        firebaseapp_contest_apikey=FIREBASEAPP_CONTEST_APIKEY,
+        firebaseapp_contest_senderid=FIREBASEAPP_CONTEST_SENDERID,
+        firebaseapp_wca=FIREBASEAPP_WCA,
+        firebaseapp_wca_apikey=FIREBASEAPP_WCA_APIKEY,
+        firebaseapp_wca_senderid=FIREBASEAPP_WCA_SENDERID,
+    )
+
 @app.route("/contest/<cid>/<eid>/timer")
 def contesttimer(cid, eid):
     return render_template(

--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -272,6 +272,14 @@ body > .container {
   color: #808080;
 }
 
+#event-info {
+  color: #808080;
+}
+
+.contestform-page {
+  color: #808080;
+}
+
 a.underlined {
   color: #e74c3c;
   text-decoration: underline;

--- a/src/templates/components/authinfo.html
+++ b/src/templates/components/authinfo.html
@@ -3,7 +3,7 @@
   <p id="event-info" class="margin-bottom-0">Demo Timer</p>
 [% else %]
   [% if eid != '' %]
-    <p id="event-info" class="margin-bottom-0">{{ events[eid].name }}</p>
+    <p id="event-info" class="margin-bottom-0">{{ events['e[[ eid ]]'].name }}</p>
   [% endif %]
 [% endif %]
 

--- a/src/templates/contestform.html
+++ b/src/templates/contestform.html
@@ -1,4 +1,4 @@
-[% set title => "Contest Form " + cid + " (" + eid + ")  %]
+[% set title = "Contest Form " + cid + " (" + eid + ")" %]
 [% set page_url = contest_url + "/contest/" + cid + "/" + eid + "/form" %]
 
 <!DOCTYPE html>
@@ -10,7 +10,7 @@
     [% import "components/basejs.html" as basejs %]
     [[ basejs.print(firebaseapp_contest, firebaseapp_contest_apikey, firebaseapp_contest_senderid, firebaseapp_wca) ]]
 </head>
-<body><div class="container">
+<body class="contestform-page"><div class="container">
     [% import "components/bodyheader.html" as bodyheader %]
     [[ bodyheader.print(title=title, contest_name=contest_name, cid=cid, eid=eid) ]]
 
@@ -50,7 +50,8 @@
 
         [% import "/contestscrambles.html" as contestscrambles %]
         [[ contestscrambles.print(eid=eid) ]]
-        @contesttimeform(eid=eid, useInput=true, clickable=true)
+        [% import "contesttimeform.html" as contesttimeform %]
+        [[ contesttimeform.print(eid=eid, useInput=True, clickable=True) ]]
 
         <p id="input-completed" class="margin-top-20 text-center hide">
             入力が完了しました。間違いがなければ確認ページへ進んでください。<br>
@@ -88,7 +89,7 @@
 <script>
 app.controller('ContestFormCtrl', ['$scope', '$timeout', function($scope, $timeout) {
 
-if(eid == "333fm") {
+if('[[ eid ]]' == "333fm") {
 
     $scope.invalidPage = true;
     $scope.contestFormLoaded = true;


### PR DESCRIPTION
## 概要
Scala版にあった記録入力フォームの単独ページ `/contest/<cid>/<eid>/form` がPython版に移植されていなかったため移植しました。あわせて、一度もレンダリングされていなかった `contestform.html` の潜在バグを修正しました。

## 変更内容
`src/app.py`
- `/contest/<cid>/<eid>/form` ルートを追加（`contestform.html` をレンダリング）

`src/templates/contestform.html`（移植漏れ・Scala残骸の修正）
- 1行目 `[% set title => "...  %]`（`=>` 誤記＋閉じ忘れ）→ 正しい `[% set title = ... %]`
- Scala/Twirl の `@contesttimeform(...)` → Jinja の `[% import %]` ＋ `[[ contesttimeform.print(...) ]]`
- コントローラ内の素の `eid`（未定義で Angular がブート失敗）→ `'[[ eid ]]'`
- ページ全体のテキスト色を `#808080` に（`<body class="contestform-page">`）

`src/templates/components/authinfo.html`
- 種目名の表示 `{{ events[eid].name }}`（素の eid で空表示）→ `{{ events['e[[ eid ]]'].name }}`。`authinfo.print(eid=...)` を使う他ページ（timer/confirm/solution）でも種目名が出るようになる

`src/public/stylesheets/main.css`
- `#event-info` と `.contestform-page` の文字色を `#808080`