### PR TITLE
Set timer page text color to gray

### DIFF
--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -14,6 +14,10 @@ body {
   font-family: "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", "メイリオ",
     Meiryo, "ＭＳ Ｐゴシック", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
+
+.contesttimer-page {
+  color: #808080;
+}
 h1,
 h2,
 h3,

--- a/src/templates/contesttimer.html
+++ b/src/templates/contesttimer.html
@@ -19,7 +19,7 @@
 
     <script src="/assets/audiojs/audiojs/audio.tribox.js" type="text/javascript"></script>
 </head>
-<body><div class="container">
+<body class="contesttimer-page"><div class="container">
     [% import "components/bodyheader.html" as bodyheader %]
     [[ bodyheader.print(title=title, contest_name=contest_name, cid=cid, eid=eid) ]]
 


### PR DESCRIPTION
## 概要
タイマーページ（`/contest/<cid>/<eid>/timer`）の本文テキスト色を #808080 にしました。

## 変更内容
`src/templates/contesttimer.html`
- `<body class="contesttimer-page">` を付与

`src/public/stylesheets/main.css`
- `.contesttimer-page { color: #808080; }` を追加

ヘッダー/フッターやエラー赤文字などは各自の色指定があるため影響しません。