### PR TITLE
Use blue for buttons on top, login, logout, and join pages

### DIFF
--- a/src/public/stylesheets/index.css
+++ b/src/public/stylesheets/index.css
@@ -36,7 +36,7 @@
   display: inline-block;
   padding: 8px 16px;
   border-radius: 8px;
-  background: linear-gradient(-15deg, #009678, #0096af);
+  background: #0088cc;
   color: #ffffff;
   font-size: 13px;
   font-weight: bold;

--- a/src/public/stylesheets/login.css
+++ b/src/public/stylesheets/login.css
@@ -66,7 +66,7 @@
   padding: 12px;
   border: none;
   border-radius: 8px;
-  background: linear-gradient(-15deg, #009678, #0096af);
+  background: #0088cc;
   color: #ffffff;
   font-size: 15px;
   font-weight: bold;


### PR DESCRIPTION
## 概要
トップページ・ログイン・ログアウト・新規登録のボタンの色を、リンクと同じ青（#0088CC）に統一しました。

## 変更内容
`src/public/stylesheets/login.css`
- `.auth-submit`（ログイン／新規登録／ログアウトのボタン）の背景をティールグラデから `#0088cc` に

`src/public/stylesheets/index.css`
- `.index-info-btn`（トップの「練習用コンテストタイマー」ボタン）の背景を `#0088cc` に