### PR TITLE
Fix footer width and match mobile footer to about.tribox.com

### DIFF
--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -213,13 +213,26 @@ body > .container {
 
 #footer-inner {
   width: 100%;
-  max-width: 928px;
-  margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 12px 24px;
+}
+
+@media screen and (max-width: 697px) {
+  #footer {
+    min-height: 107px;
+  }
+  #footer-inner {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  #footer-copyright {
+    text-align: center;
+    font-size: 12px;
+  }
 }
 
 #footer-nav {


### PR DESCRIPTION
## 概要
フッターの幅を直し、スマホ表示を about.tribox.com のモバイルフッターに合わせました。

## 変更内容
`src/public/stylesheets/main.css`
- **幅**: `#footer-inner` の `max-width: 928px; margin: 0 auto` を撤去し、ページ本文（`.container`）と同じ幅に。ナビ（左）とコピーライト（右）がページ内容の端と揃う
- **スマホ（≤697px）**: about.tribox.com に合わせて縦並び・中央寄せに
  - `#footer { min-height: 107px }`
  - `#footer-inner { flex-direction: column; align-items: center; justify-content: center }`
  - `#footer-copyright { text-align: center; font-size: 12px }`