### PR TITLE
Show deadline hour in 24-hour format

### DIFF
--- a/src/templates/components/basejs.html
+++ b/src/templates/components/basejs.html
@@ -269,9 +269,7 @@
     var timestampToDeadline = function(timestamp) {
         var weekDaysJa = ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日'];
         var d = new Date(timestamp);
-        var hour = d.getHours() % 12;
-        if (hour === 0) { hour = 12; }
-        return d.getFullYear() + '/' + (d.getMonth() + 1) + '/' + d.getDate() + ' ' + weekDaysJa[d.getDay()] + ' ' + hour + '時';
+        return d.getFullYear() + '/' + (d.getMonth() + 1) + '/' + d.getDate() + ' ' + weekDaysJa[d.getDay()] + ' ' + d.getHours() + '時';
     };
     app.filter('toDeadline', [function() {
         return timestampToDeadline;


### PR DESCRIPTION
## 概要
トップページの締切表示の時刻を12時間表記から24時間表記に変更しました（例: 9時 → 21時）。

## 変更内容
`src/templates/components/basejs.html`
- `toDeadline` フィルタの時刻を `d.getHours() % 12` から `d.getHours()`（24時間表記）に変更