### PR TITLE
Restyle about page to match the site design

### DIFF
--- a/src/public/stylesheets/about.css
+++ b/src/public/stylesheets/about.css
@@ -4,367 +4,246 @@
 
 /* Hero Section */
 .about-hero-section {
-    color: #333;
-    padding: 32px 24px;
-    margin: 0 0 32px 0;
-    text-align: center;
-    position: relative;
-}
-
-@media (min-width: 768px) {
-    .about-hero-section {
-        padding: 40px 32px;
-    }
+  text-align: center;
+  padding: 8px 0 24px;
+  margin-bottom: 24px;
 }
 
 .about-hero-title {
-    font-size: 1.8em;
-    font-weight: bold;
-    margin-bottom: 12px;
-    color: #333;
-    position: relative;
-    display: inline-block;
-}
-
-.about-hero-title::after {
-    content: '';
-    position: absolute;
-    bottom: -8px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 60px;
-    height: 3px;
-    background: linear-gradient(-15deg, #009678, #0096af);
-}
-
-@media (max-width: 480px) {
-    .about-hero-title {
-        font-size: 1.5em;
-    }
+  font-size: 22px;
+  font-weight: bold;
+  color: #808080;
+  margin-bottom: 12px;
 }
 
 .about-hero-subtitle {
-    font-size: 1em;
-    color: #666;
-    max-width: 600px;
-    margin: 20px auto 0;
-    line-height: 1.6;
+  font-size: 14px;
+  color: #808080;
+  line-height: 1.8;
+  max-width: 600px;
+  margin: 0 auto;
 }
 
 /* Cards */
 .about-card-container {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-    margin-bottom: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 32px;
 }
 
 .about-card {
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    padding: 24px;
-    transition: all 0.3s ease;
-}
-
-.about-card:hover {
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-    transform: translateY(-2px);
+  background: #ffffff;
+  border: 1px solid #e6e6e6;
+  border-radius: 12px;
+  padding: 20px 24px;
 }
 
 .about-card-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
 }
 
 .about-card-icon {
-    width: 40px;
-    height: 40px;
-    background: linear-gradient(-15deg, #009678, #0096af);
-    border-radius: 8px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: white;
-    font-size: 20px;
-    flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #009678;
+  font-size: 22px;
+  flex-shrink: 0;
+}
+
+.about-card-icon img {
+  height: 24px;
+  width: auto;
+  max-width: none;
 }
 
 .about-card-title {
-    font-size: 1.4em;
-    font-weight: bold;
-    color: #333;
-    margin: 0;
+  font-size: 16px;
+  font-weight: bold;
+  color: #808080;
+  margin: 0;
 }
 
 .about-card-content {
-    color: #666;
-    line-height: 1.8;
+  color: #808080;
+  font-size: 14px;
+  line-height: 1.8;
 }
 
 .about-card-content p {
-    margin: 12px 0;
+  margin: 10px 0;
 }
 
-/* Features Grid */
-.about-features-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 20px;
-    margin: 32px 0;
-}
-
-.about-feature-card {
-    background: linear-gradient(135deg, #f5f5f5 0%, #ffffff 100%);
-    border-radius: 12px;
-    padding: 20px;
-    border: 1px solid #e0e0e0;
-    transition: all 0.3s ease;
-}
-
-.about-feature-card:hover {
-    border-color: #0096af;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 150, 175, 0.15);
-}
-
-.about-feature-icon {
-    width: 48px;
-    height: 48px;
-    background: linear-gradient(-15deg, #009678, #0096af);
-    border-radius: 12px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: white;
-    font-size: 24px;
-    margin-bottom: 12px;
-}
-
-.about-feature-title {
-    font-weight: bold;
-    color: #333;
-    margin-bottom: 8px;
-    font-size: 1.1em;
-}
-
-.about-feature-description {
-    color: #666;
-    font-size: 0.95em;
-    line-height: 1.6;
+.about-card-content a:not(.about-cta-button) {
+  color: #0088cc;
 }
 
 /* Prize Table */
 .about-prize-section {
-    margin: 40px 0;
+  margin: 32px 0;
 }
 
 .about-prize-title {
-    font-size: 1.8em;
-    font-weight: bold;
-    text-align: center;
-    margin-bottom: 8px;
-    background: linear-gradient(-15deg, #009678, #0096af);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  font-size: 18px;
+  font-weight: bold;
+  text-align: center;
+  color: #808080;
+  margin-bottom: 8px;
 }
 
 .about-prize-subtitle {
-    text-align: center;
-    color: #666;
-    margin-bottom: 24px;
+  text-align: center;
+  color: #808080;
+  font-size: 13px;
+  margin-bottom: 16px;
 }
 
 .about-prize-table-container {
-    overflow-x: auto;
-    margin: 20px 0;
+  overflow-x: auto;
+  margin: 16px 0;
 }
 
 .about-prize-table {
-    width: 100%;
-    max-width: 700px;
-    margin: 0 auto;
-    border-collapse: separate;
-    border-spacing: 0;
-    border-radius: 12px;
-    overflow: hidden;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 700px;
+  margin: 0 auto;
+  color: #808080;
+  border-collapse: collapse;
 }
 
-.about-prize-table th, .about-prize-table td {
-    padding: 16px;
-    text-align: center;
+.about-prize-table th,
+.about-prize-table td {
+  padding: 12px 16px;
+  text-align: center;
+  border-bottom: 1px solid #cccccc;
 }
 
 .about-prize-table th {
-    font-weight: bold;
-    color: white;
-    background: linear-gradient(-15deg, #009678, #0096af);
+  font-weight: bold;
+  color: #808080;
 }
 
 .about-prize-table th.about-gold {
-    background: linear-gradient(135deg, #FFD700, #FFA500);
+  color: #c8a000;
 }
 
 .about-prize-table th.about-silver {
-    background: linear-gradient(135deg, #C0C0C0, #A8A8A8);
+  color: #999999;
 }
 
 .about-prize-table th.about-bronze {
-    background: linear-gradient(135deg, #CD7F32, #B87333);
-}
-
-.about-prize-table td {
-    background: white;
-    border-bottom: 1px solid #f0f0f0;
-}
-
-.about-prize-table tr:last-child td {
-    border-bottom: none;
+  color: #b87333;
 }
 
 .about-prize-table td:first-child {
-    background: #f8f9fa;
-    font-weight: 500;
+  font-weight: bold;
 }
 
 .about-prize-table .about-prize-amount {
-    font-weight: bold;
-    font-size: 1.1em;
-    color: #333;
+  font-weight: bold;
+  color: #808080;
 }
 
 /* CTA Buttons */
 .about-cta-container {
-    display: flex;
-    gap: 12px;
-    margin: 20px 0;
-    flex-wrap: wrap;
-    justify-content: center;
+  display: flex;
+  gap: 12px;
+  margin: 16px 0;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .about-cta-button {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 10px 20px;
-    background: linear-gradient(-15deg, #009678, #0096af);
-    color: white !important;
-    border-radius: 6px;
-    text-decoration: none !important;
-    font-weight: 500;
-    font-size: 0.95em;
-    transition: all 0.3s ease;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 20px;
+  background: #0088cc;
+  color: #ffffff !important;
+  border-radius: 8px;
+  text-decoration: none !important;
+  font-weight: bold;
+  font-size: 14px;
 }
 
 .about-cta-button:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-    color: white !important;
+  opacity: 0.92;
+  color: #ffffff !important;
 }
 
 .about-cta-button-secondary {
-    background: white;
-    color: #0096af !important;
-    border: 1.5px solid #0096af;
+  background: #ffffff;
+  color: #0088cc !important;
+  border: 1px solid #0088cc;
 }
 
 .about-cta-button-secondary:hover {
-    background: #f8fcff;
-    color: #0096af !important;
+  background: #f5fbff;
+  color: #0088cc !important;
+  opacity: 1;
 }
 
 /* Info Box */
 .about-info-box {
-    background: linear-gradient(135deg, #f0f9ff 0%, #e6f4ff 100%);
-    border-left: 4px solid #0096af;
-    border-radius: 8px;
-    padding: 20px;
-    margin: 20px 0;
+  background: #f7f7f7;
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin: 16px 0;
 }
 
 .about-info-box-title {
-    font-weight: bold;
-    color: #0096af;
-    margin-bottom: 8px;
-    font-size: 1.1em;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.about-info-box-title i {
-    font-size: 1.1em;
+  font-weight: bold;
+  color: #808080;
+  margin-bottom: 8px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .about-info-box-content {
-    color: #666;
-    line-height: 1.6;
+  color: #808080;
+  font-size: 13px;
+  line-height: 1.7;
 }
 
 .about-info-box-content i {
-    color: #009678;
-    margin-right: 8px;
-}
-
-/* Section Divider */
-.about-section-divider {
-    height: 2px;
-    background: linear-gradient(90deg, transparent, #0096af, transparent);
-    margin: 40px 0;
+  color: #009678;
+  margin-right: 8px;
 }
 
 /* Icon styles */
-.about-icon-link {
-    color: #0096af;
-    font-size: 1.2em;
-    margin-right: 4px;
-}
-
 .about-icon-store {
-    color: #009678;
+  color: #0088cc;
 }
 
 /* Responsive adjustments */
 @media (max-width: 480px) {
-    .about-card {
-        padding: 16px;
-    }
+  .about-card {
+    padding: 16px;
+  }
 
-    .about-card-title {
-        font-size: 1.2em;
-    }
+  .about-card-title {
+    font-size: 15px;
+  }
 
-    .about-cta-button {
-        width: 100%;
-        justify-content: center;
-    }
+  .about-cta-button {
+    width: 100%;
+    justify-content: center;
+  }
 
-    .about-prize-table {
-        font-size: 0.9em;
-    }
+  .about-prize-table {
+    font-size: 13px;
+  }
 
-    .about-prize-table th, .about-prize-table td {
-        padding: 10px 8px;
-    }
-}
-
-/* Animation */
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-.about-animate-in {
-    animation: fadeInUp 0.6s ease-out forwards;
+  .about-prize-table th,
+  .about-prize-table td {
+    padding: 10px 8px;
+  }
 }

--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -127,7 +127,7 @@
             <div class="about-card">
               <div class="about-card-header">
                 <div class="about-card-icon">
-                  <i class="fa fa-gift"></i>
+                  <img src="/assets/images/icons/crown.png" alt="抽選ポイント" />
                 </div>
                 <h3 class="about-card-title">抽選ポイント</h3>
               </div>


### PR DESCRIPTION
## 概要
/about ページのデザインを、いかにも"AI生成"風（派手なグラデ・色付きアイコンタイル・ホバー浮き・グラデのテーブル等）から、サイト全体の基調（#808080グレー・控えめなカード・青リンク/ボタン・グラデ最小限）に合わせて整えました。HTMLのクラス構成は維持し、主に `about.css` を刷新しています。

## 変更内容
`src/public/stylesheets/about.css`
- テキストを #808080 に統一（#333/#666 をやめ）
- カードアイコンの色付きグラデタイルを廃止 → ティール(#009678)のシンプルアイコン
- カードを薄い枠線(#e6e6e6)＋角丸に、ホバー浮き上がり演出を削除
- 見出しのグラデ文字 → ソリッド #808080
- ボタンを青(#0088CC)に統一（セカンダリは青枠）
- 賞金テーブルをサイトのテーブル調（#ccc 下線・文字#808080、順位のみ金/銀/銅の文字色で控えめに区別）
- 情報ボックスの左アクセントボーダー（AIっぽい）と青グラデを廃止 → 薄グレー背景のシンプルなボックス
- fadeInアニメ・未使用CSS（features grid 等）を削除
- triboxストアのリンクを青(#0088CC)に

`src/templates/about.html`
- 抽選ポイントカードのアイコンを王冠（`crown.png`、結果ページの当選者と統一）に変更