### PR TITLE
Restyle regulations page to match the site design

### DIFF
--- a/src/public/stylesheets/regulations.css
+++ b/src/public/stylesheets/regulations.css
@@ -1,0 +1,49 @@
+.regulations-content {
+  color: #808080;
+}
+
+.regulations-content h2 {
+  font-size: 22px;
+  font-weight: bold;
+  color: #808080;
+  margin-bottom: 12px;
+}
+
+.regulations-content h4 {
+  font-size: 16px;
+  font-weight: bold;
+  color: #808080;
+  margin-top: 32px;
+  margin-bottom: 8px;
+}
+
+.regulations-content p {
+  font-size: 14px;
+  line-height: 1.9;
+}
+
+.regulations-content ol {
+  font-size: 14px;
+  line-height: 1.9;
+}
+
+.regulations-content ol.alpha,
+.regulations-content ol.alpha li {
+  list-style-type: upper-alpha;
+}
+
+.regulations-content a {
+  color: #0088cc;
+}
+
+.regulations-content hr {
+  border: none;
+  border-top: 1px solid #e6e6e6;
+  margin: 32px 0;
+}
+
+@media screen and (max-width: 480px) {
+  .regulations-content h2 {
+    font-size: 20px;
+  }
+}

--- a/src/templates/regulations.html
+++ b/src/templates/regulations.html
@@ -13,24 +13,11 @@
 [% import "components/authjs.html" as authjs %]
 [[ authjs.print(redirect_login="", redirect_logout="", check_first=True) ]]
 
-<style>
-    @media screen and (max-width: 480px) {
-        h2 {
-            font-size: 1.8em;
-        }
-    }
-    h4 {
-        margin-top: 30px;
-    }
-    ol.alpha,
-    ol.alpha li {
-        list-style-type: upper-alpha !important;
-    }
-
-    p {
-        line-height: 1.6em;
-    }
-</style>
+<link
+  rel="stylesheet"
+  media="screen"
+  href="[[ url_for('static', filename='stylesheets/regulations.css') ]]"
+/>
 
 </head>
 <body><div class="container">
@@ -43,7 +30,7 @@
             <span class="sr-only">Loading...</span>
             Loading...
         </div>
-        <div ng-show="authLoaded">
+        <div ng-show="authLoaded" class="regulations-content">
 
             [% import "components/authinfo.html" as authinfo %]
             [[ authinfo.print() ]]


### PR DESCRIPTION
## 概要
/regulations ページを、サイト全体の基調（#808080グレー・青リンク・控えめな区切り線）に合わせて整えました。

## 変更内容
`src/public/stylesheets/regulations.css`（新規）
- 本文 #808080、見出し（h2 22px / h4 16px）をグレー・太字に
- リンクを #0088CC に
- `<hr>` を薄い #e6e6e6 の区切り線に
- `ol.alpha` の upper-alpha を維持、本文・リストの行間をゆったりめに

`src/templates/regulations.html`
- インライン `<style>` を `regulations.css` の読み込みに置き換え
- コンテンツラッパーに `regulations-content` クラスを付与