### PR TITLE
Replace loading spinner with centered 2D Rubik's cube loader

### DIFF
--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -600,3 +600,54 @@ table.profile td {
   font-size: 0.8em;
   line-height: 1.2em;
 }
+
+/**
+ * Loading (Rubik's cube, 2D)
+ */
+.cube-loader {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1000;
+  text-align: center;
+}
+
+.cube-loader-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 16px);
+  grid-template-rows: repeat(3, 16px);
+  gap: 4px;
+  margin: 0 auto;
+}
+
+.cube-loader-grid span {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  background-image: linear-gradient(-15deg, #009678, #0096af);
+  background-size: 56px 56px;
+  opacity: 0.2;
+  animation: cube-loader-pulse 1.2s infinite ease-in-out;
+}
+
+.cube-loader-grid span:nth-child(1) { background-position: 0 0; animation-delay: 0s; }
+.cube-loader-grid span:nth-child(2) { background-position: -20px 0; animation-delay: 0.12s; }
+.cube-loader-grid span:nth-child(3) { background-position: -40px 0; animation-delay: 0.24s; }
+.cube-loader-grid span:nth-child(4) { background-position: 0 -20px; animation-delay: 0.12s; }
+.cube-loader-grid span:nth-child(5) { background-position: -20px -20px; animation-delay: 0.24s; }
+.cube-loader-grid span:nth-child(6) { background-position: -40px -20px; animation-delay: 0.36s; }
+.cube-loader-grid span:nth-child(7) { background-position: 0 -40px; animation-delay: 0.24s; }
+.cube-loader-grid span:nth-child(8) { background-position: -20px -40px; animation-delay: 0.36s; }
+.cube-loader-grid span:nth-child(9) { background-position: -40px -40px; animation-delay: 0.48s; }
+
+@keyframes cube-loader-pulse {
+  0%, 100% { opacity: 0.2; }
+  50% { opacity: 1; }
+}
+
+.cube-loader-text {
+  margin-top: 12px;
+  color: #808080;
+  font-size: 14px;
+}

--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -26,9 +26,7 @@
 
       <div ng-controller="AuthCtrl">
         <div ng-hide="authLoaded">
-          <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-          <span class="sr-only">Loading...</span>
-          Loading...
+          <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
         </div>
         <div ng-show="authLoaded">
           [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/contest.html
+++ b/src/templates/contest.html
@@ -71,9 +71,7 @@ cid %]
             </div>
 
             <div ng-hide="authLoaded && contestLoaded && contestIndexLoaded">
-              <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-              <span class="sr-only">Loading...</span>
-              Loading...
+              <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
             </div>
             <div
               id="main-content"

--- a/src/templates/contestchoose.html
+++ b/src/templates/contestchoose.html
@@ -35,9 +35,7 @@ contest_url + "/contest/" + cid + "/" + eid + "/choose" %]
         <div ng-controller="ContestCtrl">
           <div ng-controller="ContestChooseCtrl">
             <div ng-hide="authLoaded && contestLoaded && contestChooseLoaded">
-              <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-              <span class="sr-only">Loading...</span>
-              Loading...
+              <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
             </div>
             <div ng-show="authLoaded && contestLoaded && contestChooseLoaded">
               [% import "components/authinfo.html" as authinfo %]

--- a/src/templates/contestconfirm.html
+++ b/src/templates/contestconfirm.html
@@ -21,9 +21,7 @@ contest_url + '/contest/' + 'cid' + "/" + "eid" + "/confirm" %]
         <div ng-controller="ContestCtrl">
           <div ng-controller="ContestConfirmCtrl">
             <div ng-hide="authLoaded && contestLoaded && contestConfirmLoaded">
-              <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-              <span class="sr-only">Loading...</span>
-              Loading...
+              <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
             </div>
             <div ng-show="authLoaded && contestLoaded && contestConfirmLoaded">
               [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/contestform.html
+++ b/src/templates/contestform.html
@@ -16,9 +16,7 @@
 
     <div ng-controller="AuthCtrl"><div ng-controller="ContestCtrl"><div ng-controller="ContestFormCtrl">
     <div ng-hide="authLoaded && contestLoaded && contestFormLoaded">
-        <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
-        Loading...
+        <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
     </div>
     <div ng-show="authLoaded && contestLoaded && contestFormLoaded">
 

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -28,9 +28,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
         <div ng-controller="ContestCtrl">
           <div ng-controller="ContestResultCtrl">
             <div ng-hide="authLoaded && contestLoaded && contestResultLoaded">
-              <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-              <span class="sr-only">Loading...</span>
-              Loading...
+              <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
             </div>
             <div
               id="main-content"

--- a/src/templates/contestsolution.html
+++ b/src/templates/contestsolution.html
@@ -29,9 +29,7 @@ contest_url + '/contest/' + cid + "/" + eid + "/solution" %]
         <div ng-controller="ContestCtrl">
           <div ng-controller="ContestSolutionCtrl">
             <div ng-hide="authLoaded && contestLoaded && contestSolutionLoaded">
-              <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-              <span class="sr-only">Loading...</span>
-              Loading...
+              <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
             </div>
             <div ng-show="authLoaded && contestLoaded && contestSolutionLoaded">
               [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/contesttimer.html
+++ b/src/templates/contesttimer.html
@@ -25,9 +25,7 @@
 
     <div ng-controller="AuthCtrl"><div ng-controller="ContestCtrl"><div ng-controller="ContestTimerCtrl">
     <div ng-hide="authLoaded && contestLoaded && contestTimerLoaded">
-        <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
-        Loading...
+        <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
     </div>
     <div ng-show="authLoaded && contestLoaded && contestTimerLoaded">
 

--- a/src/templates/contesttimerdemo.html
+++ b/src/templates/contesttimerdemo.html
@@ -36,9 +36,7 @@
         <div ng-controller="ContestCtrl">
           <div ng-controller="ContestTimerCtrl">
             <div ng-hide="authLoaded && contestLoaded && contestTimerLoaded">
-              <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-              <span class="sr-only">Loading...</span>
-              Loading...
+              <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
             </div>
             <div ng-show="authLoaded && contestLoaded && contestTimerLoaded">
               [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/forgot.html
+++ b/src/templates/forgot.html
@@ -48,9 +48,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="AuthForgotCtrl">
           <div ng-hide="authLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded">
             <h2>パスワードリセット</h2>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -36,9 +36,7 @@
         </div>
 
     <div ng-hide="authLoaded && indexLoaded">
-        <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
-        Loading...
+        <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
     </div>
     <div ng-show="authLoaded && indexLoaded">
 

--- a/src/templates/join.html
+++ b/src/templates/join.html
@@ -77,9 +77,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="AuthJoinCtrl">
           <div ng-hide="authLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded" class="auth-page">
             <div class="auth-card">

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -104,9 +104,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="AuthLoginCtrl">
           <div ng-hide="authLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded" class="auth-page">
             <div class="auth-card">

--- a/src/templates/logout.html
+++ b/src/templates/logout.html
@@ -40,9 +40,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="AuthLogoutCtrl">
           <div ng-hide="authLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded">
             [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/ranking.html
+++ b/src/templates/ranking.html
@@ -31,9 +31,7 @@
   <div ng-controller="AuthCtrl">
     <div ng-controller="RankingCtrl">
       <div ng-hide="authLoaded && rankingLoaded">
-        <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
-        Loading...
+        <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
       </div>
       <div ng-show="authLoaded && rankingLoaded">
         [% import "components/authinfo.html" as authinfo %]

--- a/src/templates/rankingpuzzle.html
+++ b/src/templates/rankingpuzzle.html
@@ -33,9 +33,7 @@ page_url = contest_url + "ranking/" + sid + "/puzzle" %]
       <div ng-controller="AuthCtrl">
         <div ng-controller="RankingPuzzleCtrl">
           <div ng-hide="authLoaded && rankingPuzzleLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded && rankingPuzzleLoaded">
             [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/rankingpuzzleall.html
+++ b/src/templates/rankingpuzzleall.html
@@ -32,9 +32,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="RankingPuzzleCtrl">
           <div ng-hide="authLoaded && rankingPuzzleLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded && rankingPuzzleLoaded">
             [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/regulations.html
+++ b/src/templates/regulations.html
@@ -26,9 +26,7 @@
 
     <div ng-controller="AuthCtrl">
         <div ng-hide="authLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
         </div>
         <div ng-show="authLoaded" class="regulations-content">
 

--- a/src/templates/setting.html
+++ b/src/templates/setting.html
@@ -107,9 +107,7 @@ app.controller('AuthSettingCtrl', ['$scope', '$firebaseObject', 'Auth', function
 
     <div ng-controller="AuthCtrl"><div ng-controller="AuthSettingCtrl">
     <div ng-hide="authLoaded && settingLoaded">
-        <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
-        Loading...
+        <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
     </div>
     <div ng-show="authLoaded && settingLoaded">
 

--- a/src/templates/settingemail.html
+++ b/src/templates/settingemail.html
@@ -95,9 +95,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="AuthEmailCtrl">
           <div ng-hide="authLoaded && settingLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded && settingLoaded">
             [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/settingfirst.html
+++ b/src/templates/settingfirst.html
@@ -226,9 +226,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="AuthFirstSettingCtrl">
           <div ng-hide="authLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded">
             [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/settingpassword.html
+++ b/src/templates/settingpassword.html
@@ -97,9 +97,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="AuthPasswordCtrl">
           <div ng-hide="authLoaded && settingLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded && settingLoaded">
             [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/settingusername.html
+++ b/src/templates/settingusername.html
@@ -251,9 +251,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="AuthUsernameCtrl">
           <div ng-hide="authLoaded && settingLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded && settingLoaded">
             [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/unverify.html
+++ b/src/templates/unverify.html
@@ -115,9 +115,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="UnverifyCtrl">
           <div ng-hide="authLoaded && unverifyLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded && unverifyLoaded">
             [% import "components/authinfo.html" as authinfo %] [[

--- a/src/templates/user.html
+++ b/src/templates/user.html
@@ -48,9 +48,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="UserCtrl">
           <div ng-hide="authLoaded && userLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div
             id="main-content"

--- a/src/templates/verify.html
+++ b/src/templates/verify.html
@@ -57,9 +57,7 @@
       <div ng-controller="AuthCtrl">
         <div ng-controller="VerifyCtrl">
           <div ng-hide="authLoaded && verifyLoaded">
-            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
-            Loading...
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
           </div>
           <div ng-show="authLoaded && verifyLoaded">
             [% import "components/authinfo.html" as authinfo %] [[


### PR DESCRIPTION
## 概要
全ページのローディング表示を、画面中央に出る2Dのルービックキューブ風ローダーに刷新しました。

## 変更内容
全テンプレート（26ファイル）
- `<i class="fa fa-spinner fa-pulse fa-2x fa-fw">` ＋ 「Loading...」のブロックを、`.cube-loader`（3×3グリッド＋「Loading...」テキスト）に置換

`src/public/stylesheets/main.css`
- `.cube-loader`: `position: fixed` で画面中央に配置、下に「Loading...」（#808080）
- `.cube-loader-grid`: 3×3（16px×9マス、gap 4px）の2Dグリッド
- 9マス全体で1枚のティールグラデ（`linear-gradient(-15deg, #009678, #0096af)`）を構成（各マスは `background-size: 56px` ＋ `background-position` で全体グラデのスライスを表示）
- `cube-loader-pulse` で opacity（0.2⇔1）を対角方向に波打たせるアニメーション

## 補足
- 配色はサイト基調のティールグラデに統一。3D回転ではなく2D表現