### PR TITLE
Fix footer copyright centering on mobile

### DIFF
--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -220,21 +220,6 @@ body > .container {
   gap: 12px 24px;
 }
 
-@media screen and (max-width: 697px) {
-  #footer {
-    min-height: 107px;
-  }
-  #footer-inner {
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-  }
-  #footer-copyright {
-    text-align: center;
-    font-size: 12px;
-  }
-}
-
 #footer-nav {
   display: flex;
   align-items: center;
@@ -280,6 +265,21 @@ body > .container {
 #footer-copyright a {
   color: #e6e6e6;
   text-decoration: underline;
+}
+
+@media screen and (max-width: 697px) {
+  #footer {
+    min-height: 107px;
+  }
+  #footer-inner {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  #footer-copyright {
+    text-align: center;
+    font-size: 12px;
+  }
 }
 
 /**


### PR DESCRIPTION
## 概要
スマホ表示でフッターのコピーライト（2行）が中央揃えにならない不具合を修正しました。

## 原因
モバイル用の `@media (max-width: 697px)` の `#footer-copyright { text-align: center }` より**後ろ**に、ベースの `#footer-copyright { text-align: right }` が定義されており、同詳細度で後勝ちしてスマホでも右寄せになっていました。

## 変更内容
`src/public/stylesheets/main.css`
- フッターのモバイル用 `@media` ブロックを、ベースの `#footer-copyright` ルールより後ろに移動。スマホで `text-align: center` が効くように