### PR TITLE
Restyle user profile page to match site design

### DIFF
--- a/src/public/stylesheets/user.css
+++ b/src/public/stylesheets/user.css
@@ -79,6 +79,13 @@ html {
   white-space: nowrap;
 }
 
+/* 記録なしの案内 */
+.user-empty-note {
+  font-size: 14px;
+  color: #808080;
+  margin: 8px 0 24px;
+}
+
 /* 種目見出し */
 .user-event-title {
   display: flex;
@@ -97,8 +104,57 @@ html {
 }
 
 /* 参加履歴テーブル (contestresult-table を流用) */
+/* 固定レイアウト＋各列に幅を持たせ、狭い時は横スクロール（潰さない） */
 .user-history-table {
   margin-bottom: 40px;
+  table-layout: fixed;
+}
+
+/* 入りきらない時だけ横スクロール */
+.user-history-table-wrap {
+  overflow-x: auto;
+}
+
+/* PC幅では各列を十分に確保し、足りない時だけ横スクロール（モバイルは既存の縮小ルールに任せる） */
+@media screen and (min-width: 769px) {
+  .user-history-table {
+    min-width: 760px;
+  }
+}
+
+/* 個々の記録は1行で表示する（列幅は固定） */
+.user-history-details {
+  white-space: nowrap;
+}
+
+.user-history-col-details {
+  width: 340px;
+}
+
+/* キューブ名は列幅に収め、長い時は省略表示(…) */
+.user-history-table .contestresult-table-puzzle,
+.user-history-table .contestresult-table-line-clamp {
+  min-width: 0;
+}
+
+/* ビデオ公開予約の注意書き */
+.user-video-note {
+  font-size: 14px;
+  color: #808080;
+  line-height: 1.8;
+  margin: 8px 0 40px;
+}
+
+.user-video-note i.fa-hand-o-up {
+  margin-right: 4px;
+}
+
+.user-video-note a {
+  color: #0088cc;
+}
+
+.user-video-note a:hover {
+  color: #006699;
 }
 
 /* カラムの揃えを左に統一 */
@@ -124,10 +180,10 @@ html {
   width: 88px;
 }
 
-/* 開催中テーブルは内容にあわせて伸縮させる */
+/* 開催中テーブル: 4列を均等幅に */
 .user-inprogress-table {
-  table-layout: auto;
-  width: auto;
+  table-layout: fixed;
+  width: 100%;
 }
 
 /* ビデオURL入力 */

--- a/src/public/stylesheets/user.css
+++ b/src/public/stylesheets/user.css
@@ -1,0 +1,162 @@
+/**
+ * user.css - User profile page styles
+ */
+
+html {
+  scroll-behavior: smooth;
+}
+
+/* セクション見出し */
+.user-section-title {
+  font-size: 20px;
+  font-weight: bold;
+  color: #808080;
+  margin: 40px 0 16px;
+}
+
+.user-subtitle {
+  font-size: 16px;
+  font-weight: bold;
+  color: #808080;
+  margin: 0 0 12px;
+}
+
+/* プロフィール */
+.user-name {
+  font-size: 22px;
+  font-weight: bold;
+  color: #808080;
+  margin-bottom: 16px;
+}
+
+.user-name .user-verified {
+  color: #0088cc;
+  font-size: 18px;
+}
+
+.user-name .user-id {
+  font-size: 14px;
+  font-weight: normal;
+  color: #b3b3b3;
+  margin-left: 4px;
+}
+
+.user-profile-table {
+  color: #808080;
+  border-collapse: collapse;
+  margin-bottom: 32px;
+}
+
+.user-profile-table th,
+.user-profile-table td {
+  font-size: 14px;
+  text-align: left;
+  vertical-align: top;
+  padding: 6px 0;
+  line-height: 1.6;
+}
+
+.user-profile-table th {
+  font-weight: bold;
+  white-space: nowrap;
+  width: 1%;
+  padding-right: 24px;
+}
+
+.user-profile-table a {
+  color: #0088cc;
+}
+
+.user-profile-table a:hover {
+  color: #006699;
+}
+
+/* 過去シーズン選択カルーセル (contestresult-picker-contest を流用) */
+.user-season-item {
+  width: auto;
+  min-width: 34px;
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
+/* 種目見出し */
+.user-event-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 18px;
+  font-weight: bold;
+  color: #808080;
+  margin: 32px 0 8px;
+}
+
+.user-event-sp {
+  font-size: 14px;
+  color: #808080;
+  margin-bottom: 12px;
+}
+
+/* 参加履歴テーブル (contestresult-table を流用) */
+.user-history-table {
+  margin-bottom: 40px;
+}
+
+/* カラムの揃えを左に統一 */
+.user-history-table th,
+.user-history-table td {
+  text-align: left;
+}
+
+/* 順位列: 王冠が折り返さないよう幅を確保して横並びにする */
+.user-history-table .contestresult-table-col-place {
+  width: 76px;
+}
+
+.user-history-table td:nth-child(2) {
+  white-space: nowrap;
+}
+
+.user-history-table td:nth-child(2) .lottery {
+  margin-left: 2px;
+}
+
+.user-history-col-contest {
+  width: 88px;
+}
+
+/* 開催中テーブルは内容にあわせて伸縮させる */
+.user-inprogress-table {
+  table-layout: auto;
+  width: auto;
+}
+
+/* ビデオURL入力 */
+.user-video-input {
+  width: auto;
+  max-width: 220px;
+  margin: 0 8px 0 0;
+  padding: 6px 10px;
+  font-size: 14px;
+  color: #808080;
+  border: 1px solid #e6e6e6;
+  border-radius: 6px;
+  vertical-align: middle;
+}
+
+.user-video-btn {
+  display: inline-block;
+  padding: 7px 16px;
+  background: #0088cc;
+  color: #ffffff !important;
+  font-size: 14px;
+  font-weight: bold;
+  border-radius: 6px;
+  text-decoration: none !important;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.user-video-btn:hover {
+  opacity: 0.92;
+  color: #ffffff !important;
+}

--- a/src/templates/user.html
+++ b/src/templates/user.html
@@ -39,6 +39,16 @@
         cursor: pointer;
       }
     </style>
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="[[ url_for('static', filename='stylesheets/contestresult.css') ]]"
+    />
+    <link
+      rel="stylesheet"
+      media="screen"
+      href="[[ url_for('static', filename='stylesheets/user.css') ]]"
+    />
   </head>
   <body>
     <div class="container">
@@ -100,18 +110,17 @@
             </div>
 
             <div ng-show="existsUser && !suspendedUser && !deletedUser">
-              <h2>
+              <h2 class="user-name">
                 {{ thisUserData.displayname }}
-                <span style="font-size: 60%; color: #999">[[id]]</span>
                 <i
-                  class="fa fa-check-circle"
-                  style="color: #3498db"
+                  class="fa fa-check-circle user-verified"
                   title="認証済みアカウント"
                   ng-if="thisUserData.isTriboxCustomer"
                 ></i>
+                <span class="user-id">[[id]]</span>
               </h2>
 
-              <table class="profile">
+              <table class="user-profile-table">
                 <tbody>
                   <tr>
                     <th>所属</th>
@@ -160,91 +169,86 @@
                 </tbody>
               </table>
 
-              <h3>今シーズンのコンテスト参加履歴</h3>
+              <h3 class="user-section-title">今シーズンのコンテスト参加履歴</h3>
 
-              <h4>競技一覧</h4>
-              <p ng-if="authData.uid == thisUsername.uid">
-                <span ng-repeat="toc in tocMyHtml">
-                  <span ng-show="$index != 0"> / </span>
-                  <a href="#{{ toc.eid | removeHead }}">{{ toc.name }}</a>
-                </span>
-              </p>
-              <p ng-if="authData.uid != thisUsername.uid">
-                <span ng-repeat="toc in tocHtml">
-                  <span ng-show="$index != 0"> / </span>
-                  <a href="#{{ toc.eid | removeHead }}">{{ toc.name }}</a>
-                </span>
-              </p>
-
-              <p><i class="fa fa-star color-star"></i>: 当選ポイント獲得</p>
+              <div ng-show="(authData.uid == thisUsername.uid) || hasParticipatedEvents">
+                <h4 class="user-subtitle">競技一覧</h4>
+                <div class="contestresult-picker-event">
+                  <a
+                    class="contestresult-picker-event-item"
+                    ng-repeat="(eid, e) in events"
+                    ng-if="(authData.uid == thisUsername.uid) || participatedEvents[eid]"
+                    href="#{{ eid | removeHead }}"
+                  >
+                    <span class="contestresult-picker-event-label">{{ eventShortNames[eid] || events[eid].name }}</span>
+                    <img class="contestresult-picker-event-icon" ng-src="/assets/images/icons/{{ eventIcons[eid] }}" width="24" height="24" alt="{{ events[eid].name }}" />
+                  </a>
+                </div>
+              </div>
 
               <div ng-repeat="(eid, e) in events">
                 <div
                   ng-if="(authData.uid == thisUsername.uid) || (authData.uid != thisUsername.uid && history[eid])"
                 >
-                  <h4 id="{{ eid | removeHead }}">
-                    <span
-                      class="cubing-icon event-{{ eid | removeHead }}"
-                      style="vertical-align: baseline"
-                    ></span>
+                  <h4 class="user-event-title" id="{{ eid | removeHead }}">
+                    <span class="cubing-icon event-{{ eid | removeHead }}"></span>
                     {{ events[eid].name }}
                   </h4>
 
-                  <p>
+                  <p class="user-event-sp">
                     合計獲得シーズンポイント:
                     <b>{{ sumSeasonPoint[eid] }}</b> ポイント
                   </p>
 
                   <table
-                    class="table table-bordered inProgress"
-                    style="width: auto"
+                    class="contestresult-table user-inprogress-table"
                     ng-if="authData.uid && authData.uid == thisUsername.uid"
                   >
-                    <thead>
+                    <thead class="contestresult-table-header">
                       <tr>
-                        <th>開催中</th>
-                        <th>参加状況</th>
-                        <th>記録</th>
-                        <th>ビデオURL</th>
+                        <th class="contestresult-table-cell-padded">開催中</th>
+                        <th class="contestresult-table-cell-padded">参加状況</th>
+                        <th class="contestresult-table-cell-padded">記録</th>
+                        <th class="contestresult-table-cell-padded">ビデオURL</th>
                       </tr>
                     </thead>
                     <tbody>
-                      <tr>
-                        <td>
+                      <tr class="contestresult-table-body-item">
+                        <td class="contestresult-table-cell-padded">
                           <a
+                            class="contestresult-table-link"
                             href="/contest/{{ inProgress.contest | removeHead }}"
                             ng-show="!(inProgressContest._dummy)"
                             >第{{ inProgressContest.number }}節</a
                           >
                         </td>
                         <td
-                          class="color-success"
+                          class="contestresult-table-cell-padded color-success"
                           ng-if="historyInProgress[eid]"
                         >
                           <i class="fa fa-check-circle"></i> 参加済み
                         </td>
                         <td
-                          class="color-error"
+                          class="contestresult-table-cell-padded color-error"
                           ng-if="!(historyInProgress[eid])"
                         >
                           未参加
                         </td>
-                        <td>
+                        <td class="contestresult-table-cell-padded">
                           <span ng-show="historyInProgress[eid]">
                             {{ historyInProgress[eid].resultF }}
                           </span>
                         </td>
-                        <td>
+                        <td class="contestresult-table-cell-padded">
                           <span ng-show="historyInProgress[eid]">
                             <input
                               type="url"
                               placeholder="URLを入力"
-                              class="form-control"
-                              style="width: auto; margin-bottom: 0"
+                              class="user-video-input"
                               ng-model="videoUrlInput[eid]"
                             />
                             <a
-                              class="btn video-url"
+                              class="user-video-btn"
                               ng-click="updateVideoUrl(inProgress.contest, eid);"
                               >登録</a
                             >
@@ -273,106 +277,94 @@
                     にビデオが公開されるように設定してください。
                   </p>
 
-                  <table
-                    class="table table-bordered result tribox-contest margin-bottom-40"
-                    ng-if="history[eid]"
-                  >
-                    <thead>
+                  <table class="contestresult-table user-history-table" ng-if="history[eid]">
+                    <thead class="contestresult-table-header">
                       <tr>
-                        <th></th>
-                        <th>順位</th>
-                        <th>獲得SP</th>
-                        <th
-                          ng-if="eid != 'e333fm' && (events[eid].method == 'average' || events[eid].method == 'mean')"
-                        >
-                          平均記録
+                        <th class="contestresult-table-cell-padded user-history-col-contest">節</th>
+                        <th class="contestresult-table-text-align-end contestresult-table-col-place">順位</th>
+                        <th class="contestresult-table-text-align-center contestresult-table-col-sp">SP</th>
+                        <th class="contestresult-table-text-align-center contestresult-table-col-moves" ng-if="eid == 'e333fm'">手数</th>
+                        <th class="contestresult-table-text-align-end contestresult-table-col-avg" ng-if="eid != 'e333fm'">記録</th>
+                        <th class="contestresult-table-cell-padded contestresult-table-hide-mobile">
+                          <span ng-if="eid != 'e333fm'">個々の記録</span>
+                          <span ng-if="eid == 'e333fm'">解答・解説コメント</span>
                         </th>
-                        <th
-                          ng-if="eid != 'e333fm' && events[eid].method == 'best'"
-                        >
-                          最高記録
+                        <th class="contestresult-table-cell-padded contestresult-table-col-puzzle">
+                          <img class="contestresult-table-show-mobile" src="/assets/images/icons/cube_empty.png" height="24" title="パズル" alt="パズル" />
+                          <span class="contestresult-table-hide-mobile">パズル</span>
                         </th>
-                        <th ng-if="eid == 'e333fm'">記録</th>
-                        <th class="mb-hide" ng-if="eid != 'e333fm'">
-                          個々の記録
+                        <th class="contestresult-table-cell-padded contestresult-table-col-video">
+                          <i class="fa fa-video-camera"></i>
                         </th>
-                        <th class="mb-hide" ng-if="eid == 'e333fm'">
-                          解答・解説コメント
-                        </th>
-                        <th>使用キューブ</th>
-                        <th><i class="fa fa-video-camera"></i></th>
                       </tr>
                     </thead>
                     <tbody>
                       <tr
+                        class="contestresult-table-body-item"
                         id="{{ eid }}-{{ c.contestId }}"
                         ng-repeat="c in history[eid] | orderBy:'-contestId'"
                       >
-                        <td>
+                        <td class="contestresult-table-cell-padded">
                           <a
+                            class="contestresult-table-link"
                             href="/contest/result/{{ c.contestId }}/{{ eid | removeHead }}"
                             >第{{ c.contest.number }}節</a
                           >
                         </td>
-                        <td>
-                          {{ c.result.place }}
+                        <td class="contestresult-table-text-align-end">
+                          {{ c.result.place }}位
                           <span class="lottery" ng-show="c.result.lottery">
-                            <i class="fa fa-star color-star"></i>
+                            <img class="contestresult-lottery-crown" src="/assets/images/icons/crown.png" alt="当選" />
                           </span>
                         </td>
-                        <td
-                          ng-if="c.result.seasonPoint && c.result.seasonPoint != 0"
-                        >
-                          {{ c.result.seasonPoint }}
+                        <td class="contestresult-table-text-align-center">
+                          <span ng-show="c.result.seasonPoint">{{ c.result.seasonPoint }}p</span>
                         </td>
                         <td
-                          ng-if="!(c.result.seasonPoint) || c.result.seasonPoint == 0"
-                        ></td>
-                        <td>{{ c.result.resultF }}</td>
-                        <td class="mb-hide" ng-if="eid != 'e333fm'">
+                          class="contestresult-table-font-bold"
+                          ng-class="eid == 'e333fm' ? 'contestresult-table-text-align-center' : 'contestresult-table-text-align-end'"
+                        >{{ c.result.resultF }}</td>
+                        <td class="contestresult-table-cell-padded contestresult-table-hide-mobile" ng-if="eid != 'e333fm'">
                           {{ c.result.detailsF }}
                         </td>
                         <td
-                          class="mb-hide"
+                          class="contestresult-table-cell-padded contestresult-table-hide-mobile"
                           ng-if="eid == 'e333fm'"
                           id="e333fm-{{ c.contestId }}-show"
                         >
-                          <a
-                            class="cursor-pointer"
-                            ng-click="showDetail(c.contestId)"
-                            >表示</a
-                          >
+                          <a class="contestresult-table-link cursor-pointer" ng-click="showDetail(c.contestId)">表示</a>
                         </td>
-                        <td ng-show="c.result.puzzle.type == 'database'">
-                          <a
-                            href="https://store.tribox.com/products/detail.php?product_id={{ c.result.puzzle.product }}"
-                            target="_blank"
-                            >{{ c.result.puzzleF }}</a
-                          >
+                        <td class="contestresult-table-cell-padded contestresult-table-col-puzzle">
+                          <div class="contestresult-table-puzzle">
+                            <img
+                              src="https://store.tribox.com/user_data/img/category/{{ c.result.puzzle.brand }}.png"
+                              ng-show="c.result.puzzle.brand"
+                              height="24"
+                            />
+                            <a
+                              class="contestresult-table-line-clamp contestresult-table-link-default-color contestresult-table-hide-mobile"
+                              ng-if="c.result.puzzle.type == 'database'"
+                              href="https://store.tribox.com/products/detail.php?product_id={{ c.result.puzzle.product }}"
+                              target="_blank"
+                            >{{ c.result.puzzleF }}</a>
+                            <span class="contestresult-table-hide-mobile" ng-if="c.result.puzzle.type != 'database'">{{ c.result.puzzleF }}</span>
+                          </div>
                         </td>
-                        <td
-                          ng-show="c.result.puzzle.type == 'nodatabase' || c.result.puzzle.type == 'unknown'"
-                        >
-                          {{ c.result.puzzleF }}
-                        </td>
-                        <td ng-if="c.result.videoUrl">
-                          <a
-                            href="{{ c.result.videoUrl | encodeURI }}"
-                            target="_blank"
-                            ><i class="fa fa-video-camera"></i
-                          ></a>
+                        <td class="contestresult-table-cell-padded">
+                          <a ng-if="c.result.videoUrl" href="{{ c.result.videoUrl | encodeURI }}" target="_blank">
+                            <i class="fa fa-video-camera"></i>
+                          </a>
                           <i
                             class="color-success fa fa-check-circle"
-                            ng-show="c.result.videoIsAccepted != null && c.result.videoIsAccepted == true"
+                            ng-show="c.result.videoIsAccepted == true"
                             title="承認済み"
                           ></i>
                           <i
                             class="color-error fa fa-ban"
-                            ng-show="c.result.videoIsAccepted != null && c.result.videoIsAccepted == false"
+                            ng-show="c.result.videoIsAccepted == false"
                             title="非承認"
                           ></i>
                         </td>
-                        <td ng-if="!(c.result.videoUrl)"></td>
                       </tr>
                     </tbody>
                   </table>
@@ -381,251 +373,136 @@
 
               <!-- 過去シーズン -->
 
-              <hr />
-              <h3>過去のシーズンのコンテスト参加履歴</h3>
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20252"
-                ng-click="showPastSeason(20252)"
-                >2025 後半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty"
-                id="show-past-20251"
-                ng-click="showPastSeason(20251)"
-                >2025 前半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20242"
-                ng-click="showPastSeason(20242)"
-                >2024 後半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty"
-                id="show-past-20241"
-                ng-click="showPastSeason(20241)"
-                >2024 前半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20232"
-                ng-click="showPastSeason(20232)"
-                >2023 後半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty"
-                id="show-past-20231"
-                ng-click="showPastSeason(20231)"
-                >2023 前半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20222"
-                ng-click="showPastSeason(20222)"
-                >2022 後半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty"
-                id="show-past-20221"
-                ng-click="showPastSeason(20221)"
-                >2022 前半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20212"
-                ng-click="showPastSeason(20212)"
-                >2021 後半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty"
-                id="show-past-20211"
-                ng-click="showPastSeason(20211)"
-                >2021 前半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20202"
-                ng-click="showPastSeason(20202)"
-                >2020 後半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty"
-                id="show-past-20201"
-                ng-click="showPastSeason(20201)"
-                >2020 前半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20192"
-                ng-click="showPastSeason(20192)"
-                >2019 後半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty"
-                id="show-past-20191"
-                ng-click="showPastSeason(20191)"
-                >2019 前半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20182"
-                ng-click="showPastSeason(20182)"
-                >2018 後半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty"
-                id="show-past-20181"
-                ng-click="showPastSeason(20181)"
-                >2018 前半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20172"
-                ng-click="showPastSeason(20172)"
-                >2017 後半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty"
-                id="show-past-20171"
-                ng-click="showPastSeason(20171)"
-                >2017 前半期</a
-              >
-              <a
-                class="cursor-pointer btn btn-empty btn-success"
-                id="show-past-20162"
-                ng-click="showPastSeason(20162)"
-                >2016 後半期</a
-              >
+              <h3 class="user-section-title">過去のシーズンのコンテスト参加履歴</h3>
+
+              <div class="contestresult-info">
+                <div class="contestresult-picker-contest user-season-picker">
+                  <a
+                    class="contestresult-picker-contest-item user-season-item"
+                    ng-repeat="s in pastSeasonsList"
+                    ng-class="{'active contestresult-gradient-border': s.id == selectedPastSeason}"
+                    ng-click="selectPastSeason(s.id)"
+                    >{{ s.short }}</a
+                  >
+                </div>
+              </div>
 
               <div ng-show="isShownPastSeason">
-                <h4>競技一覧</h4>
-                <p>
-                  <span ng-repeat="toc in tocHtmlPast">
-                    <span ng-show="$index != 0"> / </span>
-                    <a href="#past-{{ toc.eid | removeHead }}"
-                      >{{ toc.name }}</a
+                <div ng-show="hasParticipatedEventsPast">
+                  <h4 class="user-subtitle">競技一覧</h4>
+                  <div class="contestresult-picker-event">
+                    <a
+                      class="contestresult-picker-event-item"
+                      ng-repeat="(eid, e) in events"
+                      ng-if="participatedEventsPast[eid]"
+                      href="#past-{{ eid | removeHead }}"
                     >
-                  </span>
-                </p>
-
-                <p><i class="fa fa-star color-star"></i>: 当選ポイント獲得</p>
+                      <span class="contestresult-picker-event-label">{{ eventShortNames[eid] || events[eid].name }}</span>
+                      <img class="contestresult-picker-event-icon" ng-src="/assets/images/icons/{{ eventIcons[eid] }}" width="24" height="24" alt="{{ events[eid].name }}" />
+                    </a>
+                  </div>
+                </div>
 
                 <div ng-repeat="(eid, e) in events">
                   <div ng-if="historyPast[eid]">
-                    <h4 id="past-{{ eid | removeHead }}">
-                      <span
-                        class="cubing-icon event-{{ eid | removeHead }}"
-                        style="vertical-align: baseline"
-                      ></span>
+                    <h4 class="user-event-title" id="past-{{ eid | removeHead }}">
+                      <span class="cubing-icon event-{{ eid | removeHead }}"></span>
                       {{ events[eid].name }}
                     </h4>
 
-                    <p>
+                    <p class="user-event-sp">
                       合計獲得シーズンポイント:
                       <b>{{ sumSeasonPointPast[eid] }}</b> ポイント
                     </p>
 
-                    <table
-                      class="table table-bordered result tribox-contest margin-bottom-40"
-                      ng-if="historyPast[eid]"
-                    >
-                      <thead>
+                    <table class="contestresult-table user-history-table" ng-if="historyPast[eid]">
+                      <thead class="contestresult-table-header">
                         <tr>
-                          <th></th>
-                          <th>順位</th>
-                          <th>獲得SP</th>
-                          <th
-                            ng-if="eid != 'e333fm' && (events[eid].method == 'average' || events[eid].method == 'mean')"
-                          >
-                            平均記録
+                          <th class="contestresult-table-cell-padded user-history-col-contest">節</th>
+                          <th class="contestresult-table-text-align-end contestresult-table-col-place">順位</th>
+                          <th class="contestresult-table-text-align-center contestresult-table-col-sp">SP</th>
+                          <th class="contestresult-table-text-align-center contestresult-table-col-moves" ng-if="eid == 'e333fm'">手数</th>
+                          <th class="contestresult-table-text-align-end contestresult-table-col-avg" ng-if="eid != 'e333fm'">記録</th>
+                          <th class="contestresult-table-cell-padded contestresult-table-hide-mobile">
+                            <span ng-if="eid != 'e333fm'">個々の記録</span>
+                            <span ng-if="eid == 'e333fm'">解答・解説コメント</span>
                           </th>
-                          <th
-                            ng-if="eid != 'e333fm' && events[eid].method == 'best'"
-                          >
-                            最高記録
+                          <th class="contestresult-table-cell-padded contestresult-table-col-puzzle">
+                            <img class="contestresult-table-show-mobile" src="/assets/images/icons/cube_empty.png" height="24" title="パズル" alt="パズル" />
+                            <span class="contestresult-table-hide-mobile">パズル</span>
                           </th>
-                          <th ng-if="eid == 'e333fm'">記録</th>
-                          <th class="mb-hide" ng-if="eid != 'e333fm'">
-                            個々の記録
+                          <th class="contestresult-table-cell-padded contestresult-table-col-video">
+                            <i class="fa fa-video-camera"></i>
                           </th>
-                          <th class="mb-hide" ng-if="eid == 'e333fm'">
-                            解答・解説コメント
-                          </th>
-                          <th>使用キューブ</th>
-                          <th><i class="fa fa-video-camera"></i></th>
                         </tr>
                       </thead>
                       <tbody>
                         <tr
+                          class="contestresult-table-body-item"
                           id="{{ eid }}-{{ c.contestId }}"
                           ng-repeat="c in historyPast[eid] | orderBy:'-contestId'"
                         >
-                          <td>
+                          <td class="contestresult-table-cell-padded">
                             <a
+                              class="contestresult-table-link"
                               href="/contest/result/{{ c.contestId }}/{{ eid | removeHead }}"
                               >第{{ c.contest.number }}節</a
                             >
                           </td>
-                          <td>
-                            {{ c.result.place }}
+                          <td class="contestresult-table-text-align-end">
+                            {{ c.result.place }}位
                             <span class="lottery" ng-show="c.result.lottery">
-                              <i class="fa fa-star color-star"></i>
+                              <img class="contestresult-lottery-crown" src="/assets/images/icons/crown.png" alt="当選" />
                             </span>
                           </td>
-                          <td
-                            ng-if="c.result.seasonPoint && c.result.seasonPoint != 0"
-                          >
-                            {{ c.result.seasonPoint }}
+                          <td class="contestresult-table-text-align-center">
+                            <span ng-show="c.result.seasonPoint">{{ c.result.seasonPoint }}p</span>
                           </td>
                           <td
-                            ng-if="!(c.result.seasonPoint) || c.result.seasonPoint == 0"
-                          ></td>
-                          <td>{{ c.result.resultF }}</td>
-                          <td class="mb-hide" ng-if="eid != 'e333fm'">
+                            class="contestresult-table-font-bold"
+                            ng-class="eid == 'e333fm' ? 'contestresult-table-text-align-center' : 'contestresult-table-text-align-end'"
+                          >{{ c.result.resultF }}</td>
+                          <td class="contestresult-table-cell-padded contestresult-table-hide-mobile" ng-if="eid != 'e333fm'">
                             {{ c.result.detailsF }}
                           </td>
                           <td
-                            class="mb-hide"
+                            class="contestresult-table-cell-padded contestresult-table-hide-mobile"
                             ng-if="eid == 'e333fm'"
                             id="e333fm-{{ c.contestId }}-show"
                           >
-                            <a
-                              class="cursor-pointer"
-                              ng-click="showDetailPast(c.contestId)"
-                              >表示</a
-                            >
+                            <a class="contestresult-table-link cursor-pointer" ng-click="showDetailPast(c.contestId)">表示</a>
                           </td>
-                          <td ng-show="c.result.puzzle.type == 'database'">
-                            <a
-                              href="https://store.tribox.com/products/detail.php?product_id={{ c.result.puzzle.product }}"
-                              target="_blank"
-                              >{{ c.result.puzzleF }}</a
-                            >
+                          <td class="contestresult-table-cell-padded contestresult-table-col-puzzle">
+                            <div class="contestresult-table-puzzle">
+                              <img
+                                src="https://store.tribox.com/user_data/img/category/{{ c.result.puzzle.brand }}.png"
+                                ng-show="c.result.puzzle.brand"
+                                height="24"
+                              />
+                              <a
+                                class="contestresult-table-line-clamp contestresult-table-link-default-color contestresult-table-hide-mobile"
+                                ng-if="c.result.puzzle.type == 'database'"
+                                href="https://store.tribox.com/products/detail.php?product_id={{ c.result.puzzle.product }}"
+                                target="_blank"
+                              >{{ c.result.puzzleF }}</a>
+                              <span class="contestresult-table-hide-mobile" ng-if="c.result.puzzle.type != 'database'">{{ c.result.puzzleF }}</span>
+                            </div>
                           </td>
-                          <td
-                            ng-show="c.result.puzzle.type == 'nodatabase' || c.result.puzzle.type == 'unknown'"
-                          >
-                            {{ c.result.puzzleF }}
-                          </td>
-                          <td ng-if="c.result.videoUrl">
-                            <a
-                              href="{{ c.result.videoUrl | encodeURI }}"
-                              target="_blank"
-                              ><i class="fa fa-video-camera"></i
-                            ></a>
+                          <td class="contestresult-table-cell-padded">
+                            <a ng-if="c.result.videoUrl" href="{{ c.result.videoUrl | encodeURI }}" target="_blank">
+                              <i class="fa fa-video-camera"></i>
+                            </a>
                             <i
                               class="color-success fa fa-check-circle"
-                              ng-show="c.result.videoIsAccepted != null && c.result.videoIsAccepted == true"
+                              ng-show="c.result.videoIsAccepted == true"
                               title="承認済み"
                             ></i>
                             <i
                               class="color-error fa fa-ban"
-                              ng-show="c.result.videoIsAccepted != null && c.result.videoIsAccepted == false"
+                              ng-show="c.result.videoIsAccepted == false"
                               title="非承認"
                             ></i>
                           </td>
-                          <td ng-if="!(c.result.videoUrl)"></td>
                         </tr>
                       </tbody>
                     </table>
@@ -676,11 +553,16 @@
 
       [% include "components/bodyfooter.html" %]
 
+      [% import "components/contestpickerjs.html" as contestpickerjs %]
+      [[ contestpickerjs.print(cid="", eid="") ]]
+
       <script>
         app.controller("UserCtrl", [
           "$scope",
           "$timeout",
           function ($scope, $timeout) {
+            ContestPicker.initScope($scope);
+
             $scope.thisUserData = null;
             $scope.thisUsername = null;
             $scope.userLoaded = false;
@@ -695,6 +577,8 @@
             $scope.contestsArray = [];
 
             $scope.history = {};
+            $scope.participatedEvents = {};
+            $scope.hasParticipatedEvents = false;
             $scope.historyInProgress = {};
             $scope.sumSeasonPoint = {};
             $scope.videoUrlInput = {};
@@ -702,6 +586,8 @@
             $scope.tocMyHtml = [];
 
             $scope.historyPast = {};
+            $scope.participatedEventsPast = {};
+            $scope.hasParticipatedEventsPast = false;
             $scope.sumSeasonPointPast = {};
             $scope.tocHtmlPast = [];
 
@@ -830,6 +716,7 @@
                                                 }
                                               );
 
+                                              var participated = {};
                                               Object.keys(events).forEach(
                                                 function (eid) {
                                                   Object.keys(contests).forEach(
@@ -854,6 +741,7 @@
                                                             eid
                                                           ].hasCompeted == true
                                                         ) {
+                                                          participated[eid] = true;
                                                           // 必要な分の結果だけ読み込む
                                                           contestRef
                                                             .child("results")
@@ -954,6 +842,11 @@
                                                 $scope.thisUsername =
                                                   snapUsername.val();
                                                 $scope.events = events;
+                                                $scope.participatedEvents =
+                                                  participated;
+                                                $scope.hasParticipatedEvents =
+                                                  Object.keys(participated)
+                                                    .length > 0;
                                                 $scope.inProgress = inProgress;
                                                 $scope.inProgressContest =
                                                   inProgressContest;
@@ -1040,6 +933,79 @@
                 }
               );
 
+            // FMC 解答・解説コメントの上下スライド展開
+            function getVisibleDetailColspan() {
+              var headRow = document.querySelector(
+                ".user-history-table thead tr"
+              );
+              if (!headRow) return 7;
+              var count = 0;
+              for (var i = 0; i < headRow.children.length; i++) {
+                if (
+                  window.getComputedStyle(headRow.children[i]).display !== "none"
+                ) {
+                  count++;
+                }
+              }
+              return count;
+            }
+
+            function buildFmcDetailHtml(contestId, r) {
+              var acceptedHtml = "";
+              if (r.details[0].noteIsAccepted != null) {
+                if (r.details[0].noteIsAccepted == true) {
+                  acceptedHtml =
+                    ' <span class="color-success"><i class="fa fa-check-circle"></i> 承認済み</span>';
+                } else {
+                  acceptedHtml =
+                    ' <span class="color-error"><i class="fa fa-ban"></i> 非承認</span>';
+                }
+              }
+              return (
+                '<tr id="fmc-detail-' +
+                contestId +
+                '" class="row-detail">' +
+                '<td colspan="' +
+                getVisibleDetailColspan() +
+                '" style="padding:0;border:none;">' +
+                '<div class="contestresult-table-detail-slide">' +
+                "<p><b>解答:</b><br>" +
+                TriboxContest.escapeHTML(r.details[0].solution) +
+                "</p>" +
+                "<p><b>解説コメント:</b>" +
+                acceptedHtml +
+                "<br>" +
+                TriboxContest.escapeHTML(r.details[0].note) +
+                "</p>" +
+                "</div></td></tr>"
+              );
+            }
+
+            function openFmcDetail(rowId) {
+              var slideEl = document
+                .getElementById(rowId)
+                .querySelector(".contestresult-table-detail-slide");
+              requestAnimationFrame(function () {
+                requestAnimationFrame(function () {
+                  slideEl.classList.add("open");
+                });
+              });
+            }
+
+            function closeFmcDetail(existing) {
+              var slideEl = existing.querySelector(
+                ".contestresult-table-detail-slide"
+              );
+              slideEl.classList.remove("open");
+              slideEl.addEventListener(
+                "transitionend",
+                function () {
+                  angular.element(existing).remove();
+                },
+                { once: true }
+              );
+            }
+
             var showDetailList = [];
             $scope.showDetail = function (contestId) {
               var r;
@@ -1050,57 +1016,50 @@
                 }
               });
 
-              var acceptedHtml = "<br>";
-              if (r.details[0].noteIsAccepted != null) {
-                if (r.details[0].noteIsAccepted == true) {
-                  acceptedHtml =
-                    ' <span class="color-success"><i class="fa fa-check-circle"></i> 承認済み</span><br>';
-                } else {
-                  acceptedHtml =
-                    ' <span class="color-error"><i class="fa fa-ban"></i> 非承認</span><br>';
-                }
-              }
-
+              var rowId = "fmc-detail-" + contestId;
               if (!showDetailList[contestId]) {
                 showDetailList[contestId] = true;
-                var html =
-                  '<tr id="fmc-detail-' +
-                  contestId +
-                  '" class="fmc-detail"><td colspan="6">' +
-                  "<p><b>解答:</b><br>" +
-                  TriboxContest.escapeHTML(r.details[0].solution) +
-                  "</p>" +
-                  "<p><b>解説コメント:</b>" +
-                  acceptedHtml +
-                  TriboxContest.escapeHTML(r.details[0].note) +
-                  "</p>";
                 angular
                   .element(document.getElementById("e333fm-" + contestId))
-                  .after(html);
-                //angular.element(document.getElementById('e333fm-' + contestId + '-show')).text('表示済み');
-                fadeIn(document.getElementById("fmc-detail-" + contestId));
+                  .after(buildFmcDetailHtml(contestId, r));
+                openFmcDetail(rowId);
               } else {
                 showDetailList[contestId] = false;
-                angular
-                  .element(document.getElementById("fmc-detail-" + contestId))
-                  .remove();
+                var existing = document.getElementById(rowId);
+                if (existing) closeFmcDetail(existing);
               }
             };
 
             /* 過去のシーズン表示用 */
             $scope.isShownPastSeason = false;
-            var showingSeason = "";
-            $scope.showPastSeason = function (season) {
-              // ボタン表示
-              var btnClickDOM = document.getElementById("show-past-" + season);
-              var btnPastDOM = document.getElementById(
-                "show-past-" + showingSeason
-              );
-              angular.element(btnClickDOM).removeClass("btn-empty");
-              angular.element(btnPastDOM).addClass("btn-empty");
-              showingSeason = season;
+            $scope.selectedPastSeason = null;
+            $scope.selectedPastSeasonLabel = "";
+            var pastSeasonIds = [
+              "20252", "20251", "20242", "20241", "20232", "20231",
+              "20222", "20221", "20212", "20211", "20202", "20201",
+              "20192", "20191", "20182", "20181", "20172", "20171", "20162",
+            ];
+            $scope.pastSeasonsList = pastSeasonIds.map(function (id) {
+              var year = id.slice(0, 4);
+              var isFirst = id.charAt(4) === "1";
+              return {
+                id: id,
+                short: year + (isFirst ? "前半" : "後半"),
+                label: year + " " + (isFirst ? "前半期" : "後半期"),
+              };
+            });
+
+            $scope.selectPastSeason = function (season) {
+              $scope.selectedPastSeason = "" + season;
+              $scope.pastSeasonsList.forEach(function (s) {
+                if (s.id === "" + season) {
+                  $scope.selectedPastSeasonLabel = s.label;
+                }
+              });
 
               $scope.historyPast = {};
+              $scope.participatedEventsPast = {};
+              $scope.hasParticipatedEventsPast = false;
               $scope.sumSeasonPointPast = {};
               $scope.tocHtmlPast = [];
 
@@ -1142,6 +1101,7 @@
                                       function (snapUserhistories) {
                                         var userHistories =
                                           snapUserhistories.val();
+                                        var participatedPast = {};
 
                                         // 各競技のシーズンポイント初期化
                                         Object.keys(events).forEach(function (
@@ -1168,6 +1128,7 @@
                                                   userHistories[cid][eid]
                                                     .hasCompeted == true
                                                 ) {
+                                                  participatedPast[eid] = true;
                                                   // 必要な分の結果だけ読み込む
                                                   contestRef
                                                     .child("results")
@@ -1253,6 +1214,14 @@
                                             }
                                           );
                                         });
+
+                                        $timeout(function () {
+                                          $scope.participatedEventsPast =
+                                            participatedPast;
+                                          $scope.hasParticipatedEventsPast =
+                                            Object.keys(participatedPast)
+                                              .length > 0;
+                                        });
                                       }
                                     );
                                 });
@@ -1284,40 +1253,17 @@
                 }
               });
 
-              var acceptedHtml = "<br>";
-              if (r.details[0].noteIsAccepted != null) {
-                if (r.details[0].noteIsAccepted == true) {
-                  acceptedHtml =
-                    ' <span class="color-success"><i class="fa fa-check-circle"></i> 承認済み</span><br>';
-                } else {
-                  acceptedHtml =
-                    ' <span class="color-error"><i class="fa fa-ban"></i> 非承認</span><br>';
-                }
-              }
-
+              var rowId = "fmc-detail-" + contestId;
               if (!showDetailListPast[contestId]) {
                 showDetailListPast[contestId] = true;
-                var html =
-                  '<tr id="fmc-detail-' +
-                  contestId +
-                  '" class="fmc-detail"><td colspan="6">' +
-                  "<p><b>解答:</b><br>" +
-                  TriboxContest.escapeHTML(r.details[0].solution) +
-                  "</p>" +
-                  "<p><b>解説コメント:</b>" +
-                  acceptedHtml +
-                  TriboxContest.escapeHTML(r.details[0].note) +
-                  "</p>";
                 angular
                   .element(document.getElementById("e333fm-" + contestId))
-                  .after(html);
-                //angular.element(document.getElementById('e333fm-' + contestId + '-show')).text('表示済み');
-                fadeIn(document.getElementById("fmc-detail-" + contestId));
+                  .after(buildFmcDetailHtml(contestId, r));
+                openFmcDetail(rowId);
               } else {
                 showDetailListPast[contestId] = false;
-                angular
-                  .element(document.getElementById("fmc-detail-" + contestId))
-                  .remove();
+                var existing = document.getElementById(rowId);
+                if (existing) closeFmcDetail(existing);
               }
             };
 

--- a/src/templates/user.html
+++ b/src/templates/user.html
@@ -143,8 +143,8 @@
                       <span ng-show="!(thisUserData.iso2)">Loading...</span>
                       <span ng-show="thisUserData.iso2">
                         <img
-                          src="/assets/flags/flags-iso/shiny/24/{{ thisUserData.iso2 }}.png"
-                          height="24"
+                          src="https://flagcdn.com/{{ thisUserData.iso2.toLowerCase() }}.svg"
+                          height="16"
                           style="vertical-align: middle"
                           ng-show="thisUserData.iso2"
                         />
@@ -266,18 +266,19 @@
                       </tr>
                     </tbody>
                   </table>
-                  <p ng-show="historyInProgress[eid]">
-                    <i class="fa fa-hand-o-up" style="font-weight: bold"></i>
+                  <p class="user-video-note" ng-show="historyInProgress[eid]">
+                    <i class="fa fa-hand-o-up"></i>
                     <a
                       href="https://support.google.com/youtube/answer/1270709?hl=ja"
                       target="_blank"
                       >動画の公開時刻を予約して</a
                     >、 コンテストの終了時刻
-                    <i>{{ inProgressContest.endAt | toDate }}</i>
+                    <b>{{ inProgressContest.endAt | toDate }}</b>
                     にビデオが公開されるように設定してください。
                   </p>
 
-                  <table class="contestresult-table user-history-table" ng-if="history[eid]">
+                  <div class="user-history-table-wrap" ng-if="history[eid]">
+                  <table class="contestresult-table user-history-table">
                     <thead class="contestresult-table-header">
                       <tr>
                         <th class="contestresult-table-cell-padded user-history-col-contest">節</th>
@@ -285,7 +286,7 @@
                         <th class="contestresult-table-text-align-center contestresult-table-col-sp">SP</th>
                         <th class="contestresult-table-text-align-center contestresult-table-col-moves" ng-if="eid == 'e333fm'">手数</th>
                         <th class="contestresult-table-text-align-end contestresult-table-col-avg" ng-if="eid != 'e333fm'">記録</th>
-                        <th class="contestresult-table-cell-padded contestresult-table-hide-mobile">
+                        <th class="contestresult-table-cell-padded contestresult-table-hide-mobile user-history-col-details">
                           <span ng-if="eid != 'e333fm'">個々の記録</span>
                           <span ng-if="eid == 'e333fm'">解答・解説コメント</span>
                         </th>
@@ -324,7 +325,7 @@
                           class="contestresult-table-font-bold"
                           ng-class="eid == 'e333fm' ? 'contestresult-table-text-align-center' : 'contestresult-table-text-align-end'"
                         >{{ c.result.resultF }}</td>
-                        <td class="contestresult-table-cell-padded contestresult-table-hide-mobile" ng-if="eid != 'e333fm'">
+                        <td class="contestresult-table-cell-padded contestresult-table-hide-mobile user-history-details" ng-if="eid != 'e333fm'">
                           {{ c.result.detailsF }}
                         </td>
                         <td
@@ -368,6 +369,7 @@
                       </tr>
                     </tbody>
                   </table>
+                  </div>
                 </div>
               </div>
 
@@ -388,6 +390,12 @@
               </div>
 
               <div ng-show="isShownPastSeason">
+                <p
+                  class="user-empty-note"
+                  ng-show="pastSeasonLoaded && !hasParticipatedEventsPast"
+                >
+                  このシーズンの記録はありません。
+                </p>
                 <div ng-show="hasParticipatedEventsPast">
                   <h4 class="user-subtitle">競技一覧</h4>
                   <div class="contestresult-picker-event">
@@ -415,7 +423,8 @@
                       <b>{{ sumSeasonPointPast[eid] }}</b> ポイント
                     </p>
 
-                    <table class="contestresult-table user-history-table" ng-if="historyPast[eid]">
+                    <div class="user-history-table-wrap" ng-if="historyPast[eid]">
+                    <table class="contestresult-table user-history-table">
                       <thead class="contestresult-table-header">
                         <tr>
                           <th class="contestresult-table-cell-padded user-history-col-contest">節</th>
@@ -423,7 +432,7 @@
                           <th class="contestresult-table-text-align-center contestresult-table-col-sp">SP</th>
                           <th class="contestresult-table-text-align-center contestresult-table-col-moves" ng-if="eid == 'e333fm'">手数</th>
                           <th class="contestresult-table-text-align-end contestresult-table-col-avg" ng-if="eid != 'e333fm'">記録</th>
-                          <th class="contestresult-table-cell-padded contestresult-table-hide-mobile">
+                          <th class="contestresult-table-cell-padded contestresult-table-hide-mobile user-history-col-details">
                             <span ng-if="eid != 'e333fm'">個々の記録</span>
                             <span ng-if="eid == 'e333fm'">解答・解説コメント</span>
                           </th>
@@ -462,7 +471,7 @@
                             class="contestresult-table-font-bold"
                             ng-class="eid == 'e333fm' ? 'contestresult-table-text-align-center' : 'contestresult-table-text-align-end'"
                           >{{ c.result.resultF }}</td>
-                          <td class="contestresult-table-cell-padded contestresult-table-hide-mobile" ng-if="eid != 'e333fm'">
+                          <td class="contestresult-table-cell-padded contestresult-table-hide-mobile user-history-details" ng-if="eid != 'e333fm'">
                             {{ c.result.detailsF }}
                           </td>
                           <td
@@ -506,6 +515,7 @@
                         </tr>
                       </tbody>
                     </table>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -588,6 +598,7 @@
             $scope.historyPast = {};
             $scope.participatedEventsPast = {};
             $scope.hasParticipatedEventsPast = false;
+            $scope.pastSeasonLoaded = false;
             $scope.sumSeasonPointPast = {};
             $scope.tocHtmlPast = [];
 
@@ -1060,6 +1071,7 @@
               $scope.historyPast = {};
               $scope.participatedEventsPast = {};
               $scope.hasParticipatedEventsPast = false;
+              $scope.pastSeasonLoaded = false;
               $scope.sumSeasonPointPast = {};
               $scope.tocHtmlPast = [];
 
@@ -1101,7 +1113,8 @@
                                       function (snapUserhistories) {
                                         var userHistories =
                                           snapUserhistories.val();
-                                        var participatedPast = {};
+                                        var realPast = {};
+                                        var pendingPast = 0;
 
                                         // 各競技のシーズンポイント初期化
                                         Object.keys(events).forEach(function (
@@ -1128,7 +1141,7 @@
                                                   userHistories[cid][eid]
                                                     .hasCompeted == true
                                                 ) {
-                                                  participatedPast[eid] = true;
+                                                  pendingPast++;
                                                   // 必要な分の結果だけ読み込む
                                                   contestRef
                                                     .child("results")
@@ -1145,6 +1158,7 @@
                                                             !result._dummy &&
                                                             result.endAt
                                                           ) {
+                                                            realPast[eid] = true;
                                                             result.resultF =
                                                               TriboxContest.formatResult(
                                                                 result,
@@ -1207,6 +1221,18 @@
                                                             );
                                                           }
                                                         }
+                                                        pendingPast--;
+                                                        if (pendingPast === 0) {
+                                                          $timeout(function () {
+                                                            $scope.participatedEventsPast =
+                                                              realPast;
+                                                            $scope.hasParticipatedEventsPast =
+                                                              Object.keys(
+                                                                realPast
+                                                              ).length > 0;
+                                                            $scope.pastSeasonLoaded = true;
+                                                          });
+                                                        }
                                                       }
                                                     );
                                                 }
@@ -1215,13 +1241,11 @@
                                           );
                                         });
 
-                                        $timeout(function () {
-                                          $scope.participatedEventsPast =
-                                            participatedPast;
-                                          $scope.hasParticipatedEventsPast =
-                                            Object.keys(participatedPast)
-                                              .length > 0;
-                                        });
+                                        if (pendingPast === 0) {
+                                          $timeout(function () {
+                                            $scope.pastSeasonLoaded = true;
+                                          });
+                                        }
                                       }
                                     );
                                 });


### PR DESCRIPTION
`/user/<id>` のユーザーページを、サイト全体のデザインに合わせて作り直しました。

## 変更点
- **プロフィール**: 罫線を消し、グレー文字・青リンクの定義リスト型に整理。
- **競技一覧**: 結果ページ／ランキングと同じ種目アイコンピッカー（`contestresult-picker-event`）に変更。種目が揃うまで枠ごと非表示にし、表示時は一括で出るように。
- **参加履歴テーブル**: 結果ページと同じ `contestresult-table` スタイルに統一（現シーズン・過去シーズン・開催中テーブル）。当選マークは王冠アイコンに統一。
- **FMC解答・解説**: 「表示」を上から下にスライド展開する方式に変更。
- **過去シーズン**: 年度ボタンの羅列を横スクロールカルーセル（タップで選択・選択中はティール枠）に変更。種目アイコンを押すとスムーズスクロールで該当種目へ移動。
- 未使用だった c3 / d3（チャート）の読み込みを削除。

新規 `src/public/stylesheets/user.css` を追加し、ピッカー・テーブル・カルーセルは既存の `contestresult.css` を流用しています。