### PR TITLE
Show BLD (333bf) as Best of 3 instead of Avg. of 5

### DIFF
--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -142,6 +142,8 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                       <th class="contestresult-table-text-align-end contestresult-table-col-place">順位</th>
                       [% if eid == "333fm" %]
                       <th class="contestresult-table-text-align-center contestresult-table-col-moves">手数</th>
+                      [% elif eid == "333bf" %]
+                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Best of 3</th>
                       [% elif eid == "666" or eid == "777" %]
                       <th class="contestresult-table-text-align-end contestresult-table-col-avg">Mean of 3</th>
                       [% else %]

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -121,7 +121,7 @@
                         </span>
                         <span class="cubing-icon event-{{ e | removeHead }} index-event-icon"></span>
                         <span class="index-event-name">{{ events[e].name }}</span>
-                        <span class="index-event-format" ng-class="e == 'e333bf' ? 'index-format-average' : ('index-format-' + events[e].method + (events[e].method == 'best' ? events[e].attempts : ''))">{{ e == 'e333bf' ? 'Avg. of 5' : ({'average':'Avg.','mean':'Mean','best':'Best'}[events[e].method] + ' of ' + events[e].attempts) }}</span>
+                        <span class="index-event-format" ng-class="'index-format-' + events[e].method + (events[e].method == 'best' ? events[e].attempts : '')">{{ {'average':'Avg.','mean':'Mean','best':'Best'}[events[e].method] + ' of ' + events[e].attempts }}</span>
                         <span class="index-event-count"><img class="index-event-count-icon" src="/assets/images/icons/users.png" alt="" /> {{ participants[e] }}</span>
                     </a>
                 </div>


### PR DESCRIPTION
目隠し（3×3×3 BLD, `333bf`）の記録形式が「Avg. of 5」と表示されていたのを「**Best of 3**」に修正しました。イベント定義は `method: "best"` / `attempts: 3` のため、本来の Best of 3 が正しい表記です。

## 変更点
- `contestresult.html`: 記録カラムの見出し分岐に `333bf` を追加（FMC・6x6/7x7 以外が一律「Avg. of 5」に落ちていたため、BLDだけ「Best of 3」に）。
- `index.html`: トップページの種目一覧で `333bf` を「Avg. of 5」に固定していた特別扱いを削除し、通常の `method` + `attempts` ロジック（＝Best of 3）に統一。

ラベルのみの修正で、記録の値自体（ベストタイム表示）は元から正しく動作しています。