### PR TITLE
Rework contest result table for responsive breakpoints (1024px / 768px)

### DIFF
--- a/src/public/javascripts/contestresult.js
+++ b/src/public/javascripts/contestresult.js
@@ -47,3 +47,82 @@ document.querySelectorAll('tbody .contestresult-table-deploy-button').forEach(fu
     }
   });
 });
+
+
+// ==========================================================================
+// パズル名の展開/格納 (見出しのキューブアイコン / ><ボタン)
+// ==========================================================================
+(function () {
+  var table = document.querySelector('.contestresult-table');
+  if (!table) return;
+
+  var puzzleIcon = document.querySelector('th.contestresult-table-col-puzzle img.contestresult-table-show-mobile');
+  var headButton = document.querySelector('thead .contestresult-table-deploy-button');
+
+  function isRecordsDeployed() {
+    var detailTh = document.querySelector('th.contestresult-table-detail-records');
+    return !!(detailTh && detailTh.classList.contains('deploy'));
+  }
+
+  function openPuzzle() {
+    if (isRecordsDeployed() && headButton) {
+      headButton.click();
+    }
+    if (window.innerWidth <= 768) {
+      table.classList.add('puzzle-deploy');
+    }
+  }
+
+  function closePuzzle() {
+    table.classList.remove('puzzle-deploy');
+  }
+
+  if (puzzleIcon) {
+    puzzleIcon.style.cursor = 'pointer';
+    puzzleIcon.addEventListener('click', function () {
+      if (table.classList.contains('puzzle-deploy')) {
+        closePuzzle();
+      } else {
+        openPuzzle();
+      }
+    });
+  }
+
+  var collapseBtn = document.querySelector('.contestresult-puzzle-collapse-button');
+  if (collapseBtn) {
+    collapseBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      closePuzzle();
+    });
+  }
+
+  if (headButton) {
+    headButton.addEventListener('click', function () {
+      setTimeout(function () {
+        if (isRecordsDeployed() && table.classList.contains('puzzle-deploy')) {
+          closePuzzle();
+        }
+      }, 0);
+    });
+  }
+})();
+
+// ==========================================================================
+// 個々の記録カルーセル: 全行を横スクロール同期
+// ==========================================================================
+(function () {
+  var carousels = document.querySelectorAll('.contestresult-table-records');
+  if (!carousels.length) return;
+  var syncing = false;
+  carousels.forEach(function (carousel) {
+    carousel.addEventListener('scroll', function () {
+      if (syncing) return;
+      syncing = true;
+      var scrollLeft = carousel.scrollLeft;
+      carousels.forEach(function (other) {
+        if (other !== carousel) other.scrollLeft = scrollLeft;
+      });
+      syncing = false;
+    });
+  });
+})();

--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -673,95 +673,179 @@ a.contestresult-puzzle-name:hover {
   }
 }
 
-/* タブレット */
+/* ==========================================================================
+   レスポンシブ: 1024px以下 共通
+   ========================================================================== */
 @media screen and (max-width: 1024px) {
-  .contestresult-table-detail-records.deploy {
-    width: 240px;
-  }
-
-  .contestresult-table-record-items {
-    width: 48px;
-    font-size: 0.85em;
-  }
-}
-
-/* スマホ */
-@media screen and (max-width: 768px) {
-  .contestresult-table-col-sp {
-    width: 36px;
+  .contestresult-table {
+    font-size: 14px;
   }
 
   .contestresult-table-col-place {
-    width: 40px;
+    width: 48px;
   }
 
   .contestresult-table-col-avg {
     width: 72px;
-    font-size: 0.85em;
+    font-size: 1em; /* 旧デザインの0.85em指定を無効化 */
   }
 
-  .contestresult-table-col-deploy {
+  .contestresult-table-col-deploy,
+  .contestresult-table-col-deploy-body {
     width: 28px;
   }
 
-  /* deploy 列を非表示 (333fm の detail ボタンは別クラスで残す) */
-  .contestresult-table-col-deploy,
-  .contestresult-table-col-deploy-body {
+  /* SP列・ビデオ列は常に非表示 */
+  .contestresult-table-col-sp,
+  .contestresult-table-col-video {
     display: none;
   }
 
-  .contestresult-table-col-detail-body {
-    display: table-cell;
+  /* 個々の記録: displayではなくwidthで開閉することでアニメーションを効かせる */
+  .contestresult-table-detail-records {
+    width: 0;
+    padding: 0;
   }
 
-  .contestresult-table-hide-mobile {
+  .contestresult-table-header-name-offset {
+    margin-left: 36px;
+    white-space: nowrap;
+  }
+}
+
+/* 個々の記録: 732px以下は競技者列148pxを保証しつつ残りを使用 */
+@media screen and (max-width: 732px) {
+  .contestresult-table-detail-records.deploy {
+    width: calc(100% - 328px);
+  }
+  tr:has(.contestresult-table-detail-records.deploy) .contestresult-table-col-name {
+    width: 148px;
+  }
+}
+
+/* 個々の記録: 733〜1024pxは364px固定、余りは競技者列へ */
+@media screen and (min-width: 733px) and (max-width: 1024px) {
+  .contestresult-table-detail-records.deploy {
+    width: 364px;
+  }
+  .contestresult-table-col-puzzle {
+    width: 200px;
+  }
+}
+
+/* 個々の記録: 常に70px幅・12px固定 */
+.contestresult-table-record-items {
+  width: 70px;
+  font-size: 12px;
+}
+.contestresult-table-records {
+  display: flex;
+  overflow-x: auto;
+  width: 100%;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.contestresult-table-records::-webkit-scrollbar {
+  display: none;
+}
+.contestresult-table-record-items {
+  scroll-snap-align: start;
+  flex: 0 0 auto;
+}
+
+/* 記録形式・競技者見出しの短縮表記 (デフォルト非表示、狭い画面で表示) */
+.contestresult-table-show-narrow {
+  display: none;
+}
+.name-header-short {
+  display: none;
+}
+@media screen and (max-width: 1024px) {
+  .contestresult-table-hide-narrow {
     display: none;
   }
-
-  .contestresult-table-show-mobile {
+  .contestresult-table-show-narrow {
     display: inline;
   }
+}
 
-  .contestresult-hide-mobile {
-    display: none;
+/* 競技者見出しは常に短縮形「競技者」に固定 */
+.name-header-full {
+  display: none;
+}
+.name-header-short {
+  display: inline;
+}
+
+/* パズル: アイコン+名前を包むコンテナは左揃え */
+.contestresult-table-puzzle {
+  justify-content: flex-start;
+}
+
+/* パズル名リンク: displayではなくwidthで開閉(アニメーションのため) */
+.contestresult-table-col-puzzle a {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  vertical-align: middle;
+  transition: all 0.3s ease, padding 0.3s ease;
+}
+
+.contestresult-table-col-puzzle,
+.contestresult-table-col-name {
+  transition: all 0.3s ease, padding 0.3s ease;
+}
+
+/* パズル名展開時(手動トグル): 競技者列を最低100px確保しつつ、パズル列が残りを使う */
+.contestresult-table.puzzle-deploy .contestresult-table-puzzle {
+  max-width: 328px;
+}
+.contestresult-table.puzzle-deploy .contestresult-table-col-puzzle {
+  text-align: left;
+}
+.contestresult-table.puzzle-deploy .contestresult-table-col-puzzle a {
+  width: 100%;
+}
+@media screen and (min-width: 645px) {
+  .contestresult-table.puzzle-deploy .contestresult-table-col-puzzle {
+    width: 356px;
   }
-
-  /* 横開きの個々の記録を無効化 */
-  .contestresult-table-detail-records,
-  .contestresult-table-detail-records.deploy {
-    display: none;
+}
+@media screen and (max-width: 644px) {
+  .contestresult-table.puzzle-deploy .contestresult-table-col-puzzle {
+    width: calc(100% - 248px);
   }
-
-  .contestresult-table-body-item {
-    height: 40px;
+  .contestresult-table.puzzle-deploy .contestresult-table-col-name {
+    width: 100px;
   }
+}
 
-  .contestresult-table-placement,
-  .contestresult-table-name,
-  .contestresult-table-puzzle {
-    height: 40px;
+/* 769〜1199px: 個々の記録展開時はパズル名を隠してアイコンのみに */
+@media screen and (min-width: 769px) and (max-width: 1199px) {
+  tr:has(.contestresult-table-detail-records.deploy) .contestresult-table-col-puzzle a {
+    width: 0;
   }
-
-  .contestresult-table-name img {
-    height: 12px;
-  }
-
-  .contestresult-table-puzzle {
-    justify-content: center;
-  }
-
-  .contestresult-table-col-puzzle {
+  tr:has(.contestresult-table-detail-records.deploy) .contestresult-table-col-puzzle {
     width: 32px;
     text-align: center;
   }
-
-  .contestresult-picker-event-item {
-    width: 48px;
-    height: 48px;
+  tr:has(.contestresult-table-detail-records.deploy) .contestresult-table-col-puzzle .contestresult-table-show-mobile {
+    display: inline;
   }
+  tr:has(.contestresult-table-detail-records.deploy) .contestresult-table-col-puzzle .contestresult-table-hide-mobile {
+    display: none;
+  }
+}
 
-  .contestresult-puzzle-name,
-  .contestresult-puzzle-pct {
-    font-size: 14px;
+/* 769px未満: パズル名は常に非表示(アイコンのみ) */
+@media screen and (max-width: 768px) {
+  .contestresult-table-col-puzzle a {
+    width: 0;
+  }
+  .contestresult-table-col-puzzle {
+    width: 32px;
+    text-align: center;
   }
 }

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -143,11 +143,11 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                       [% if eid == "333fm" %]
                       <th class="contestresult-table-text-align-center contestresult-table-col-moves">手数</th>
                       [% elif eid == "333bf" %]
-                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Best of 3</th>
+                      <th class="contestresult-table-text-align-end contestresult-table-col-avg"><span class="contestresult-table-hide-narrow">Best of 3</span><span class="contestresult-table-show-narrow">Bo3</span></th>
                       [% elif eid == "666" or eid == "777" %]
-                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Mean of 3</th>
+                      <th class="contestresult-table-text-align-end contestresult-table-col-avg"><span class="contestresult-table-hide-narrow">Mean of 3</span><span class="contestresult-table-show-narrow">Mo3</span></th>
                       [% else %]
-                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Avg. of 5</th>
+                      <th class="contestresult-table-text-align-end contestresult-table-col-avg"><span class="contestresult-table-hide-narrow">Avg. of 5</span><span class="contestresult-table-show-narrow">Ao5</span></th>
                       [% endif %]
                       <th class="[% if eid == '333fm' %]contestresult-table-col-detail-body[% else %]contestresult-table-col-deploy[% endif %]">
                         [% if eid != "333fm" %]
@@ -164,10 +164,15 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         [% endif %]
                       </th>
                       <th class="contestresult-table-detail-records contestresult-table-cell-padded">個々の記録</th>
-                      <th class="contestresult-table-cell-padded">競技者 / 所属</th>
+                      <th class="contestresult-table-cell-padded contestresult-table-col-name"><span class="contestresult-table-header-name-offset">競技者</span></th>
                       <th class="contestresult-table-cell-padded contestresult-table-col-puzzle">
-                        <img class="contestresult-table-show-mobile" src="/assets/images/icons/cube_empty.png" height="24" title="パズル" alt="パズル" />
-                        <span class="contestresult-table-hide-mobile">パズル</span>
+                        <div class="contestresult-table-puzzle">
+                          <img class="contestresult-table-show-mobile" src="/assets/images/icons/cube_empty.png" height="24" title="パズル" alt="パズル" />
+                          <span class="contestresult-table-hide-mobile">パズル</span>
+                          <button class="contestresult-table-deploy-button contestresult-puzzle-collapse-button">
+                            <img src="/assets/images/icons/undeploy.png" height="24" title="undeploy" alt="undeploy" />
+                          </button>
+                        </div>
                       </th>
                       <th class="contestresult-table-cell-padded contestresult-table-col-video">
                         <i class="fa fa-video-camera"></i>
@@ -193,7 +198,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         </div>
                       </td>
                       <td class="contestresult-table-text-align-end">{{ r.place }}位</td>
-                      <td class="[% if eid == '333fm' %]contestresult-table-text-align-center[% else %]contestresult-table-text-align-end[% endif %] contestresult-table-font-bold">{{ r.resultF }}</td>
+                      <td class="[% if eid == '333fm' %]contestresult-table-text-align-center[% else %]contestresult-table-text-align-end[% endif %] contestresult-table-font-bold contestresult-table-cell-padded">{{ r.resultF }}</td>
                       <td class="[% if eid == '333fm' %]contestresult-table-col-detail-body[% else %]contestresult-table-col-deploy-body[% endif %]">
                         [% if eid == "333fm" %]
                         <div class="contestresult-table-deploy-button-container">
@@ -213,7 +218,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                           <div class="contestresult-table-record-items" ng-repeat="d in r.detailsF.split(' ') track by $index">{{ d }}</div>
                         </div>
                       </td>
-                      <td class="contestresult-table-cell-padded">
+                      <td class="contestresult-table-cell-padded contestresult-table-col-name">
                         <div class="contestresult-table-name">
                           <div class="contestresult-table-flag">
                             <img


### PR DESCRIPTION
## 概要
結果テーブルのレスポンシブ表示を整理し、1024px / 768pxの2境界に一本化しました。従来の768px/1024pxブロックは削除し、新しいルールに置き換えています。

## 主な変更点
- SP列・動画列は1024px以下で常に非表示
- 記録形式(Avg. of 5等)は1024px以下でAo5等の短縮表記に切り替え
- 競技者見出しは「競技者」に統一
- 個々の記録の展開/格納をdisplay:noneではなくwidthベースに変更し、アニメーションを有効化
- パズル名(メーカー名)の展開/格納機能を新規追加(見出しのキューブアイコンをクリック)。個々の記録が展開中の場合は自動的に格納
- 個々の記録が5件収まらない場合はカルーセル化(横スクロール、全行同期)
- パズル列・競技者列の幅バランスを画面幅に応じて調整

## 変更したファイル
- `src/public/stylesheets/contestresult.css`
- `src/public/javascripts/contestresult.js`
- `src/templates/contestresult.html`

## 確認方法
3x3(333)のリザルトページで、768px以下・769〜1024px・1024px超それぞれの画面幅で、個々の記録の展開/格納、パズル名の展開/格納を確認してください。