### PR TITLE
Improve contest result table on mobile

### DIFF
--- a/src/public/javascripts/contestresult.js
+++ b/src/public/javascripts/contestresult.js
@@ -1,7 +1,16 @@
 // thead の deploy ボタン: 全行の記録を一括横開き
 var headButton = document.querySelector('thead .contestresult-table-deploy-button');
 if (headButton) {
+  var animatingTimer = null;
   headButton.addEventListener('click', function() {
+    // 開閉アニメーション中は画面外の行を隠してレイアウト計算を軽くする
+    var table = this.closest('table');
+    table.classList.add('animating');
+    clearTimeout(animatingTimer);
+    animatingTimer = setTimeout(function() {
+      table.classList.remove('animating');
+    }, 350);
+
     var img = this.querySelector('img');
     var isDeployed = img.src.includes('deploy.png') && !img.src.includes('undeploy.png');
     if (isDeployed) {
@@ -16,6 +25,7 @@ if (headButton) {
     document.querySelectorAll('.contestresult-table-detail-records').forEach(function(el) {
       el.classList.toggle('deploy');
     });
+    table.classList.toggle('deployed');
   });
 }
 

--- a/src/public/javascripts/contestresult.js
+++ b/src/public/javascripts/contestresult.js
@@ -3,7 +3,6 @@ var headButton = document.querySelector('thead .contestresult-table-deploy-butto
 if (headButton) {
   var animatingTimer = null;
   headButton.addEventListener('click', function() {
-    // 開閉アニメーション中は画面外の行を隠してレイアウト計算を軽くする
     var table = this.closest('table');
     table.classList.add('animating');
     clearTimeout(animatingTimer);

--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -567,6 +567,12 @@ a.contestresult-puzzle-name:hover {
   color: #808080;
 }
 
+/* 開閉アニメーション中は画面外の行を隠して再レイアウトを軽くする
+   (deploy ボタンは thead にあり、クリック時に見えるのは先頭の行だけ) */
+.contestresult-table.animating tbody tr:nth-child(n+41) {
+  display: none;
+}
+
 /* 詳細行: main.css の row-detail border を打ち消し */
 .contestresult-table .row-detail {
   border: none;
@@ -691,31 +697,26 @@ a.contestresult-puzzle-name:hover {
 
 /* スマホ */
 @media screen and (max-width: 768px) {
+  .contestresult-table {
+    font-size: 14px;
+    min-width: 100%;
+    transition: min-width 0.3s ease;
+  }
+
   .contestresult-table-col-sp {
     width: 36px;
   }
 
   .contestresult-table-col-place {
-    width: 40px;
+    width: 48px;
   }
 
   .contestresult-table-col-avg {
-    width: 72px;
-    font-size: 0.85em;
+    width: 64px;
   }
 
   .contestresult-table-col-deploy {
     width: 28px;
-  }
-
-  /* deploy 列を非表示 (333fm の detail ボタンは別クラスで残す) */
-  .contestresult-table-col-deploy,
-  .contestresult-table-col-deploy-body {
-    display: none;
-  }
-
-  .contestresult-table-col-detail-body {
-    display: table-cell;
   }
 
   .contestresult-table-hide-mobile {
@@ -730,9 +731,28 @@ a.contestresult-puzzle-name:hover {
     display: none;
   }
 
-  /* 横開きの個々の記録を無効化 */
-  .contestresult-table-detail-records,
   .contestresult-table-detail-records.deploy {
+    width: 254px;
+  }
+
+  .contestresult-table-record-items {
+    width: 50px;
+    font-size: 12px;
+  }
+
+  /* 記録を開いてテーブルが画面幅を超えたぶんは横スクロールで見せる */
+  .contestresult-table-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* 記録列の開き分と同じだけテーブル幅を広げ、開閉中に名前・パズル列の幅が変わらないようにする */
+  .contestresult-table.deployed {
+    min-width: calc(100% + 254px);
+  }
+
+  /* スマホは1画面に映る行数が少ないので、アニメーション中に隠す行を増やす */
+  .contestresult-table.animating tbody tr:nth-child(n+26) {
     display: none;
   }
 

--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -464,6 +464,10 @@ a.contestresult-puzzle-name:hover {
   flex-shrink: 0;
 }
 
+.contestresult-table-puzzle > a:not(.contestresult-table-line-clamp) {
+  display: flex;
+}
+
 .contestresult-table-puzzle img {
   display: block;
 }

--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -567,8 +567,6 @@ a.contestresult-puzzle-name:hover {
   color: #808080;
 }
 
-/* 開閉アニメーション中は画面外の行を隠して再レイアウトを軽くする
-   (deploy ボタンは thead にあり、クリック時に見えるのは先頭の行だけ) */
 .contestresult-table.animating tbody tr:nth-child(n+41) {
   display: none;
 }
@@ -740,18 +738,15 @@ a.contestresult-puzzle-name:hover {
     font-size: 12px;
   }
 
-  /* 記録を開いてテーブルが画面幅を超えたぶんは横スクロールで見せる */
   .contestresult-table-scroll {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
   }
 
-  /* 記録列の開き分と同じだけテーブル幅を広げ、開閉中に名前・パズル列の幅が変わらないようにする */
   .contestresult-table.deployed {
     min-width: calc(100% + 254px);
   }
 
-  /* スマホは1画面に映る行数が少ないので、アニメーション中に隠す行を増やす */
   .contestresult-table.animating tbody tr:nth-child(n+26) {
     display: none;
   }

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -169,7 +169,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         <img class="contestresult-table-show-mobile" src="/assets/images/icons/cube_empty.png" height="24" title="パズル" alt="パズル" />
                         <span class="contestresult-table-hide-mobile">パズル</span>
                       </th>
-                      <th class="contestresult-table-cell-padded contestresult-table-col-video">
+                      <th class="contestresult-table-cell-padded contestresult-table-col-video contestresult-table-hide-mobile">
                         <i class="fa fa-video-camera"></i>
                       </th>
                       <th class="contestresult-table-cell-padded contestresult-table-col-admin" ng-if="usersecretData.isAdmin">運営用</th>
@@ -258,7 +258,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                           <span class="contestresult-table-hide-mobile" ng-if="r.puzzle.type != 'database'">{{ r.puzzleF }}</span>
                         </div>
                       </td>
-                      <td class="contestresult-table-cell-padded">
+                      <td class="contestresult-table-cell-padded contestresult-table-hide-mobile">
                         <a ng-if="r.videoUrl" href="{{ r.videoUrl | encodeURI }}" target="_blank">
                           <i class="fa fa-video-camera"></i>
                         </a>

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -234,9 +234,19 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                       </td>
                       <td class="contestresult-table-cell-padded contestresult-table-col-puzzle">
                         <div class="contestresult-table-puzzle">
+                          <a
+                            ng-if="r.puzzle.brand && r.puzzle.type == 'database'"
+                            href="https://store.tribox.com/products/detail.php?product_id={{ r.puzzle.product }}"
+                            target="_blank"
+                          >
+                            <img
+                              src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
+                              height="24"
+                            />
+                          </a>
                           <img
+                            ng-if="r.puzzle.brand && r.puzzle.type != 'database'"
                             src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
-                            ng-show="r.puzzle.brand"
                             height="24"
                           />
                           <a

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -133,6 +133,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
 
                 <!-- <h4>コンテスト結果</h4>
                 <p><i class="fa fa-star color-star"></i>: 当選ポイント獲得</p> -->
+                <div class="contestresult-table-scroll">
                 <table class="contestresult-table">
                   <thead
                       class="contestresult-table-header"
@@ -276,6 +277,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                     </tr>
                   </tbody>
                 </table>
+                </div>
 
                 <div class="contestresult-scramble-section">
                   <div class="contestresult-scramble-title">スクランブル</div>

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -131,8 +131,6 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                 </div>
                 </div>
 
-                <!-- <h4>コンテスト結果</h4>
-                <p><i class="fa fa-star color-star"></i>: 当選ポイント獲得</p> -->
                 <div class="contestresult-table-scroll">
                 <table class="contestresult-table">
                   <thead
@@ -311,21 +309,6 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                 </div>
                 [% endif %]
 
-                [#
-                <!--<p>usersecretData:</p>
-                <pre>{{ usersecretData | json }}</pre>-->
-                #] [#
-                <!--<p>[[ cid ]] -> contestData:</p>
-                <pre>{{ contestData | json }}</pre>-->
-                #] [#
-                <!--<pre>{{ resultsAll.e[[ eid ]] | json }}</pre>-->
-                #] [#
-                <!--<pre>{{ resultsPuzzles.e[[ eid ]] | json }}</pre>-->
-                #] [#
-                <!--<pre>{{ resultsTop3.e[[ eid ]] | json }}</pre>-->
-                #] [#
-                <!--<pre>{{ scramblesData | json }}</pre>-->
-                #]
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 変更内容

コンテスト結果ページ（/contest/result/<cid>/<eid>）のスマホ表示を改善しました。

### パズルブランドロゴをショップへのリンクに
- スマホではパズル列にブランドロゴだけが表示されるため、ロゴ自体をタップでtriboxストアの商品ページに飛べるようにしました（商品がデータベース登録品の場合のみ）
- PCでもロゴがクリック可能になります（隣の商品名リンクと同じ飛び先）

### 動画列をスマホで非表示に

### 個々の記録の開閉をスマホでも可能に
- PCと同様にヘッダーの deploy ボタンで記録5つを横一列に開閉できます
- 開いてテーブルが画面幅を超えたぶんは横スクロールで表示します
- テーブル幅の増分を記録列の開き分と同期させ、開閉中に他の列の幅が動かないようにしています
- 開閉アニメーション中は画面外の行を一時的に非表示にして再レイアウトを軽量化（313行のコンテストで実測フレーム間隔 45ms → 25ms）
- スマホの表フォントは全体14px・記録12pxに調整

## 確認
- ローカルで実データ（c2026125 / 333、313行）を使い、開閉アニメーションをフレーム単位で計測して確認
- 333fm（deploy列なし・行別詳細ボタン）への影響がないことを確認