### PR TITLE
Abbreviate average header and widen Avg column on mobile

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -710,7 +710,7 @@ a.contestresult-puzzle-name:hover {
   }
 
   .contestresult-table-col-avg {
-    width: 64px;
+    width: 70px;
   }
 
   .contestresult-table-col-deploy {

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -142,11 +142,11 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                       [% if eid == "333fm" %]
                       <th class="contestresult-table-text-align-center contestresult-table-col-moves">手数</th>
                       [% elif eid == "333bf" %]
-                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Best of 3</th>
+                      <th class="contestresult-table-text-align-end contestresult-table-col-avg"><span class="contestresult-table-hide-mobile">Best of 3</span><span class="contestresult-table-show-mobile">Bo3</span></th>
                       [% elif eid == "666" or eid == "777" %]
-                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Mean of 3</th>
+                      <th class="contestresult-table-text-align-end contestresult-table-col-avg"><span class="contestresult-table-hide-mobile">Mean of 3</span><span class="contestresult-table-show-mobile">Mo3</span></th>
                       [% else %]
-                      <th class="contestresult-table-text-align-end contestresult-table-col-avg">Avg. of 5</th>
+                      <th class="contestresult-table-text-align-end contestresult-table-col-avg"><span class="contestresult-table-hide-mobile">Avg. of 5</span><span class="contestresult-table-show-mobile">Ao5</span></th>
                       [% endif %]
                       <th class="[% if eid == '333fm' %]contestresult-table-col-detail-body[% else %]contestresult-table-col-deploy[% endif %]">
                         [% if eid != "333fm" %]


### PR DESCRIPTION
## 変更内容

コンテスト結果ページのスマホ表示の調整です。

- 結果テーブルのヘッダーをスマホでは略記にしました（Avg. of 5 → Ao5、Mean of 3 → Mo3、Best of 3 → Bo3）。フォント14px化で「Avg. of 5」が64px幅に収まらず改行されていたのを解消します。PCは従来どおりフル表記です。
- 1分超えの記録（例 1:23.45）が収まるよう、スマホのAvg列幅を64px→70pxに広げました。