### PR TITLE
Widen record item slots to fit times over one minute

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -684,11 +684,11 @@ a.contestresult-puzzle-name:hover {
 /* タブレット */
 @media screen and (max-width: 1024px) {
   .contestresult-table-detail-records.deploy {
-    width: 240px;
+    width: 324px;
   }
 
   .contestresult-table-record-items {
-    width: 48px;
+    width: 64px;
     font-size: 0.85em;
   }
 }
@@ -730,11 +730,11 @@ a.contestresult-puzzle-name:hover {
   }
 
   .contestresult-table-detail-records.deploy {
-    width: 254px;
+    width: 304px;
   }
 
   .contestresult-table-record-items {
-    width: 50px;
+    width: 60px;
     font-size: 12px;
   }
 
@@ -744,7 +744,7 @@ a.contestresult-puzzle-name:hover {
   }
 
   .contestresult-table.deployed {
-    min-width: calc(100% + 254px);
+    min-width: calc(100% + 304px);
   }
 
   .contestresult-table.animating tbody tr:nth-child(n+26) {
@@ -786,7 +786,7 @@ a.contestresult-puzzle-name:hover {
   }
 
   .contestresult-table.deployed.puzzle-deployed {
-    min-width: calc(100% + 462px);
+    min-width: calc(100% + 512px);
   }
 
   /* rtl でスクロールを右端基準にし、パズル列が左に開いて見えるようにする */


### PR DESCRIPTION
## 変更内容

コンテスト結果ページの「個々の記録」で、1分超えの記録が隣のマスと重なる問題を修正しました。

Ao5種目のベスト/ワーストは括弧付き（例 `(1:23.45)`、最長で `(12:34.56)` の10文字）になりますが、マスが固定幅（スマホ50px・タブレット48px）で `flex-shrink: 0` のため、収まらない分が隣の記録と重なっていました。

- スマホ: 記録1マス 50px→60px、開いたときの記録列 254px→304px（テーブル幅の増分も連動して再計算）
- タブレット: 記録1マス 48px→64px、記録列 240px→324px