### PR TITLE
Stack footer vertically below 969px

### DIFF
--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -265,7 +265,7 @@ body > .container {
   text-decoration: underline;
 }
 
-@media screen and (max-width: 697px) {
+@media screen and (max-width: 969px) {
   #footer {
     min-height: 107px;
   }


### PR DESCRIPTION
## 変更内容

フッターを縦並び・センター揃えにするブレークポイントを697px以下から969px以下に広げました。ナビとコピーライトが縦に積まれ、中央揃えになります。