### PR TITLE
Use 100dvh for page min-height

### DIFF
--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -182,6 +182,7 @@ h6 {
  */
 body > .container {
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## 変更内容

`body > .container` の `min-height` に `100dvh` を追加しました。

スマホでは `100vh` がアドレスバー収納時の高さを指すため、バー表示中はページが実際の画面より縦に長くなり、ローディング中など中身が短いときにも余計なスクロールが発生していました。`100dvh` は表示中のビューポート高さに追従するのでこれが解消されます。`100vh` はdvh非対応ブラウザ向けのフォールバックとして残しています。