### PR TITLE
Redirect default fallback routes server-side and fix interpolated img src

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,10 +1,13 @@
+import json
 import mysql.connector
 import os
 import re
 import secrets
 import subprocess
+import time
+import urllib.request
 
-from flask import Flask, make_response, render_template, request, send_from_directory
+from flask import Flask, make_response, redirect, render_template, request, send_from_directory
 
 from src.models.verifying import Verifying
 from src.models.customer import Customer
@@ -122,6 +125,33 @@ def regulations():
         firebaseapp_contest_apikey=FIREBASEAPP_CONTEST_APIKEY,
         firebaseapp_contest_senderid=FIREBASEAPP_CONTEST_SENDERID,
     )
+
+# ロード完了前のヘッダーメニューが指す /contest/default, /ranking/default の
+# リダイレクト先 (最新コンテストと現在のシーズン) を Firebase REST から取得する。
+_default_ids_cache = {"expiresAt": 0.0, "lastContest": "", "sid": ""}
+
+def get_default_redirect_ids():
+    now = time.time()
+    if now < _default_ids_cache["expiresAt"]:
+        return _default_ids_cache
+    base_url = "https://" + FIREBASEAPP_CONTEST + ".firebaseio.com"
+    with urllib.request.urlopen(base_url + "/inProgress.json", timeout=3) as res:
+        in_progress = json.load(res)
+    with urllib.request.urlopen(
+        base_url + "/contests/" + in_progress["contest"] + ".json", timeout=3
+    ) as res:
+        contest = json.load(res)
+    _default_ids_cache["lastContest"] = in_progress["lastContest"][1:]
+    _default_ids_cache["sid"] = str(contest["year"]) + str(contest["season"])
+    _default_ids_cache["expiresAt"] = now + 60
+    return _default_ids_cache
+
+@app.route("/contest/default")
+def contestdefault():
+    try:
+        return redirect("/contest/" + get_default_redirect_ids()["lastContest"])
+    except Exception:
+        return contest("default")
 
 @app.route("/contest/<cid>")
 def contest(cid):
@@ -291,6 +321,10 @@ def rankingpuzzleall(sid):
 
 @app.route("/ranking/default")
 def rankingdefault():
+    try:
+        return redirect("/ranking/" + get_default_redirect_ids()["sid"])
+    except Exception:
+        pass
     return render_template(
         "rankingdefault.html",
         contest_description=CONTEST_DESCRIPTION,
@@ -306,6 +340,10 @@ def rankingdefault():
 
 @app.route("/ranking/default/puzzle")
 def rankingpuzzledefault():
+    try:
+        return redirect("/ranking/" + get_default_redirect_ids()["sid"] + "/puzzle")
+    except Exception:
+        pass
     return render_template(
         "rankingpuzzledefault.html",
         contest_description=CONTEST_DESCRIPTION,

--- a/src/templates/components/headeronlyfire.html
+++ b/src/templates/components/headeronlyfire.html
@@ -3,6 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.5/angular.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.5/angular-sanitize.min.js"></script>
 <script src="https://www.gstatic.com/firebasejs/5.7.0/firebase.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/angularFire/2.3.0/angularfire.min.js"></script>
 [%- endmacro %]

--- a/src/templates/contest.html
+++ b/src/templates/contest.html
@@ -275,7 +275,7 @@ cid %]
                             <div class="contestresult-table-name">
                               <div class="contestresult-table-flag">
                                 <img
-                                  src="https://flagcdn.com/{{ r.user.iso2.toLowerCase() }}.svg"
+                                  ng-src="https://flagcdn.com/{{ r.user.iso2.toLowerCase() }}.svg"
                                   ng-show="r.user.iso2"
                                   height="16"
                                 />
@@ -295,13 +295,13 @@ cid %]
                                 href="https://store.tribox.com/products/detail.php?product_id={{ r.puzzle.product }}"
                                 target="_blank"
                               ><img
-                                src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
+                                ng-src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
                                 ng-show="r.puzzle.brand"
                                 height="24"
                               /></a>
                               <img
                                 ng-if="r.puzzle.type != 'database'"
-                                src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
+                                ng-src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
                                 ng-show="r.puzzle.brand"
                                 height="24"
                               />

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -79,7 +79,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         <img
                           class="contestresult-puzzle-brand"
                           ng-if="p.brand"
-                          ng-src="https://store.tribox.com/user_data/img/category/{{ p.brand }}.png"
+                          ng-ng-src="https://store.tribox.com/user_data/img/category/{{ p.brand }}.png"
                           height="24"
                         />
                         <span class="contestresult-puzzle-brand-placeholder" ng-if="!p.brand"></span>
@@ -112,7 +112,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         <img
                           class="contestresult-puzzle-brand"
                           ng-if="p.brand"
-                          ng-src="https://store.tribox.com/user_data/img/category/{{ p.brand }}.png"
+                          ng-ng-src="https://store.tribox.com/user_data/img/category/{{ p.brand }}.png"
                           height="24"
                         />
                         <span class="contestresult-puzzle-brand-placeholder" ng-if="!p.brand"></span>
@@ -218,7 +218,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         <div class="contestresult-table-name">
                           <div class="contestresult-table-flag">
                             <img
-                              src="https://flagcdn.com/{{ r.user.iso2.toLowerCase() }}.svg"
+                              ng-src="https://flagcdn.com/{{ r.user.iso2.toLowerCase() }}.svg"
                               ng-show="r.user.iso2"
                               height="16"
                             />
@@ -241,13 +241,13 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                             target="_blank"
                           >
                             <img
-                              src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
+                              ng-src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
                               height="24"
                             />
                           </a>
                           <img
                             ng-if="r.puzzle.brand && r.puzzle.type != 'database'"
-                            src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
+                            ng-src="https://store.tribox.com/user_data/img/category/{{ r.puzzle.brand }}.png"
                             height="24"
                           />
                           <a

--- a/src/templates/ranking.html
+++ b/src/templates/ranking.html
@@ -108,7 +108,7 @@
                     <div class="ranking-name">
                       <div class="contestresult-table-flag">
                         <img
-                          src="https://flagcdn.com/{{ data.user.iso2.toLowerCase() }}.svg"
+                          ng-src="https://flagcdn.com/{{ data.user.iso2.toLowerCase() }}.svg"
                           ng-show="data.user.iso2"
                           height="16"
                         />
@@ -131,7 +131,7 @@
                       >
                         <img
                           class="ranking-puzzle-brand"
-                          ng-src="https://store.tribox.com/user_data/img/category/{{ data.lastUsedPuzzleBrand }}.png"
+                          ng-ng-src="https://store.tribox.com/user_data/img/category/{{ data.lastUsedPuzzleBrand }}.png"
                           height="24"
                         />
                       </a>

--- a/src/templates/rankingdefault.html
+++ b/src/templates/rankingdefault.html
@@ -16,8 +16,13 @@
           contestRef
             .child("inProgress")
             .once("value", function (snapInProgress) {
-              window.location =
-                "/contest/" + removeHead(snapInProgress.val().lastContest);
+              contestRef
+                .child("contests")
+                .child(snapInProgress.val().contest)
+                .once("value", function (snapContest) {
+                  var contest = snapContest.val();
+                  window.location = "/ranking/" + contest.year + contest.season;
+                });
             });
         },
       ]);

--- a/src/templates/user.html
+++ b/src/templates/user.html
@@ -143,7 +143,7 @@
                       <span ng-show="!(thisUserData.iso2)">Loading...</span>
                       <span ng-show="thisUserData.iso2">
                         <img
-                          src="https://flagcdn.com/{{ thisUserData.iso2.toLowerCase() }}.svg"
+                          ng-src="https://flagcdn.com/{{ thisUserData.iso2.toLowerCase() }}.svg"
                           height="16"
                           style="vertical-align: middle"
                           ng-show="thisUserData.iso2"
@@ -338,7 +338,7 @@
                         <td class="contestresult-table-cell-padded contestresult-table-col-puzzle">
                           <div class="contestresult-table-puzzle">
                             <img
-                              src="https://store.tribox.com/user_data/img/category/{{ c.result.puzzle.brand }}.png"
+                              ng-src="https://store.tribox.com/user_data/img/category/{{ c.result.puzzle.brand }}.png"
                               ng-show="c.result.puzzle.brand"
                               height="24"
                             />
@@ -484,7 +484,7 @@
                           <td class="contestresult-table-cell-padded contestresult-table-col-puzzle">
                             <div class="contestresult-table-puzzle">
                               <img
-                                src="https://store.tribox.com/user_data/img/category/{{ c.result.puzzle.brand }}.png"
+                                ng-src="https://store.tribox.com/user_data/img/category/{{ c.result.puzzle.brand }}.png"
                                 ng-show="c.result.puzzle.brand"
                                 height="24"
                               />


### PR DESCRIPTION
## 変更内容

Playwrightでのサイト巡回で見つかった2つの問題の修正です。

### /contest/default, /ranking/default 系をサーバーサイドで302リダイレクト
ヘッダーメニューはデータ読み込み完了前にクリックすると `/contest/default` や `/ranking/default` に飛ぶ設計ですが、受け皿が壊れていました。

- `/ranking/default`（と `/puzzle`）: Angularの起動失敗（contestApp が依存する ngSanitize が headeronlyfire に未読込）で「Redirecting...」のまま永久に止まる
- `/contest/default`: 「存在しないコンテストです」と表示される（該当ルートなし）

クライアント側のリダイレクトだと直しても Firebase 接続待ちの数秒間「Redirecting...」が見えるため、Flask側で Firebase REST API から最新コンテスト/現在シーズンを取得（60秒キャッシュ、タイムアウト3秒）して302で即リダイレクトする方式にしました。REST取得に失敗した場合のみ従来のクライアント側リダイレクトにフォールバックします（フォールバックが機能するよう sanitize の読み込み追加と、rankingdefault の飛び先修正〔コンテスト→ランキング〕も同梱）。

### Angular補間入り src を ng-src に変更（10箇所）
国旗（flagcdn.com）とメーカーロゴ（store）の `<img>` が `src="...{{ ... }}"` になっており、Angularのコンパイル前にリテラルURL（`%7B%7B...%7D%7D`）への失敗リクエストが全ページで発生していました。`ng-src` に変更して解消しています（contestresult / contest / user / ranking）。

## 確認
- `/ranking/default` → `/ranking/20261`、`/ranking/default/puzzle` → `/ranking/20261/puzzle`、`/contest/default` → `/contest/2026125` の302を確認
- 実ブラウザで「結果ページ→読み込み完了前にSPランキング⇄リザルトを4往復」して、毎回中間ページなしで正しいページに着地することを確認
- リザルト・コンテスト・ランキング・ユーザーページ巡回で `{{ }}` 入りURLへのリクエストが0件になったことを確認