### PR TITLE
Port verifyclick template and fix interpolated scramble image src

### DIFF
--- a/src/templates/contestsolution.html
+++ b/src/templates/contestsolution.html
@@ -154,7 +154,7 @@ contest_url + '/contest/' + cid + "/" + eid + "/solution" %]
                     Scramble: {{ scramblesData.e333fm[0] }}
                   </p>
                   <img
-                    src="/assets/333fm/{{ scramblesImgData.e333fm[0] }}.png"
+                    ng-src="/assets/333fm/{{ scramblesImgData.e333fm[0] }}.png"
                     style="width: 260px; margin-bottom: 20px"
                   />
 

--- a/src/templates/verifyclick.html
+++ b/src/templates/verifyclick.html
@@ -1,0 +1,109 @@
+[% set title = "Verify Click" %]
+
+<!DOCTYPE html>
+<html lang="ja" ng-app="contestApp">
+  <head>
+    [% import "components/header.html" as header %] [[ header.print(title=title,
+    description=contest_description, sitename=contest_name) ]] [% import
+    "components/basejs.html" as basejs %] [[ basejs.print(firebaseapp_contest,
+    firebaseapp_contest_apikey, firebaseapp_contest_senderid) ]] [% import
+    "components/authjs.html" as authjs %] [[ authjs.print(redirect_login="",
+    redirect_logout="", check_first=True) ]]
+
+    <script>
+      app.controller("VerifyClickCtrl", [
+        "$scope",
+        "$timeout",
+        function ($scope, $timeout) {
+          $scope.error = null;
+          $scope.verifyClickLoaded = false;
+
+          [% if message != "" %]
+          firebase.auth().onAuthStateChanged(function (authData) {
+            if (authData) {
+              if (authData.uid == "[[ userId ]]") {
+                // 認証アカウントをセットする
+                contestRef
+                  .child("users")
+                  .child(authData.uid)
+                  .update({ isTriboxCustomer: true }, function (error) {
+                    if (error) {
+                      console.error(error);
+                    } else {
+                      contestRef
+                        .child("usersecrets")
+                        .child(authData.uid)
+                        .update(
+                          { triboxStoreCustomerId: [[ customerId ]] },
+                          function (error) {
+                            if (error) {
+                              console.error(error);
+                            } else {
+                              $timeout(function () {
+                                $scope.verifyClickLoaded = true;
+                              });
+                            }
+                          }
+                        );
+                    }
+                  });
+              } else {
+                $timeout(function () {
+                  $scope.error = "無効なURLです。";
+                  $scope.verifyClickLoaded = true;
+                });
+              }
+            } else {
+              $timeout(function () {
+                $scope.error =
+                  "ログイン済みのPC・スマートフォン・タブレット端末等で、再度このURLにアクセスしてください。";
+                $scope.verifyClickLoaded = true;
+              });
+            }
+          });
+          [% else %]
+          $timeout(function () {
+            $scope.verifyClickLoaded = true;
+          });
+          [% endif %]
+        },
+      ]);
+    </script>
+  </head>
+  <body>
+    <div class="container">
+      [% import "components/bodyheader.html" as bodyheader %] [[
+      bodyheader.print(title=title, contest_name=contest_name) ]]
+
+      <div ng-controller="AuthCtrl">
+        <div ng-controller="VerifyClickCtrl">
+          <div ng-hide="authLoaded && verifyClickLoaded">
+            <div class="cube-loader"><div class="cube-loader-grid"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div><div class="cube-loader-text">Loading...</div></div>
+          </div>
+          <div ng-show="authLoaded && verifyClickLoaded">
+            [% import "components/authinfo.html" as authinfo %] [[
+            authinfo.print() ]]
+
+            <h2>アカウント認証確認</h2>
+
+            [% if message != "" %]
+            <div class="notice-success margin-bottom-20" ng-if="!error">
+              <i class="fa fa-check"></i>
+              [[ message ]]
+            </div>
+            [% endif %] [% if errorMessage != "" %]
+            <div class="color-error margin-bottom-20">
+              エラー: [[ errorMessage ]]
+            </div>
+            [% endif %]
+            <div class="color-error margin-bottom-20" ng-if="error">
+              エラー: {{ error }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      [% include "components/bodyfooter.html" %]
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## 変更内容

サイト全ページ巡回で見つかった問題2件の修正です。

### メール認証リンク（/setting/verify/&lt;token&gt;）が500になるのを修正
`verifyclick.html` がScala版（`app/views/verifyclick.scala.html`）から未移植で、認証メールのURLを開くと `TemplateNotFound` で必ず500になっていました（DB上の認証処理は完了するのにエラー画面が出る状態）。Scala版をJinja形式に移植しています。ローディング表示は現行デザインのキューブローダーに合わせました。

### FMC解答ページのスクランブル画像を ng-src に
`contestsolution.html` のスクランブル画像が `src="...{{ }}"` のままで、Angularコンパイル前に `/assets/333fm/%7B%7B...%7D%7D.png` への404リクエストが飛んでいました（#280の修正から漏れていた箇所）。

## 確認
- 無効形式トークンで「無効なURLです。」ページが表示されることを確認（有効トークンのDB照会パスはローカルにMySQLがないため未確認。テンプレート全体はJinjaコンパイル済みで、成功分岐の変数もルートから渡されているものだけを参照）
- FMC解答ページで `{{ }}` 入りURLへのリクエストが0件になったことを確認