### PR TITLE
Introduce CSS color variables and add frontend style guide

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,96 @@
+# フロントエンド開発ガイド
+
+tribox Contest のフロントエンド（`src/templates/` と `src/public/`）を触る人向けのルール集です。
+
+## 構成
+
+```
+src/
+  templates/            Jinja2 テンプレート (ページごとに1ファイル)
+    components/         共通部品 (header, bodyheader, bodyfooter, basejs, authjs など)
+  public/
+    stylesheets/        CSS (main.css = 全ページ共通、それ以外はページ別)
+    javascripts/        ページ別 JS
+    skyblue/            ベンダーCSS (編集禁止)
+```
+
+- フレームワークは AngularJS 1.7 + Firebase Realtime Database。データは基本クライアントサイドで取得・描画します。
+- サーバーは Flask（`src/app.py`）。ルートはテンプレートを返すだけの薄い作りです。
+
+## Jinja と Angular のデリミタ
+
+AngularJS と衝突するため、Jinja のデリミタを変更しています（`src/app.py` 参照）。
+
+| 記法 | 処理系 | 実行タイミング |
+|---|---|---|
+| `[[ ... ]]` `[% ... %]` `[# ... #]` | Jinja2 | サーバーサイド（レンダリング時） |
+| `{{ ... }}` `ng-*` | AngularJS | クライアントサイド（データ取得後） |
+
+## img の src に Angular の補間を書かない
+
+`src="...{{ ... }}"` と書くと、Angular がコンパイルする前にブラウザが
+`%7B%7B...%7D%7D` というリテラル URL へリクエストして 404 になります。
+**Angular の値を含む画像 URL は必ず `ng-src` を使ってください。**
+
+```html
+<!-- NG: ページ表示のたびに失敗リクエストが飛ぶ -->
+<img src="https://flagcdn.com/{{ r.user.iso2 }}.svg" />
+
+<!-- OK -->
+<img ng-src="https://flagcdn.com/{{ r.user.iso2 }}.svg" />
+```
+
+## 色は CSS 変数を使う
+
+パレットは `main.css` 先頭の `:root` に定義しています（main.css は全ページで読み込まれます）。
+
+| 変数 | 値 | 用途 |
+|---|---|---|
+| `--color-brand-1` / `--color-brand-2` | #0096af / #009678 | ブランドカラー（teal） |
+| `--gradient-brand` | -15deg | ヘッダー・フッター・アクティブ状態の背景 |
+| `--gradient-brand-vertical` / `--gradient-brand-horizontal` | to bottom / to right | 見出しテキスト・区切り線など |
+| `--color-text` | #808080 | 基本テキスト |
+| `--color-text-strong` | #555 | 強調・ホバー |
+| `--color-text-muted` | #999 | 補助テキスト |
+| `--color-text-light` | #e6e6e6 | 濃い背景上の明るいテキスト（フッター等） |
+| `--color-link` / `--color-link-hover` | #0088cc / #006699 | リンク |
+| `--color-surface-hover` | #f5f5f5 | ホバー背景 |
+| `--color-surface-muted` | #f7f7f7 | 淡い背景（パネル・ゼブラ・表ヘッダ） |
+| `--color-border` / `--color-border-light` / `--color-border-lighter` | #ccc / #ddd / #ececec | ボーダー（濃→淡） |
+| `--color-error` / `--color-success` | #e74c3c / #1bbc9b | エラー・成功表示 |
+| `--shadow-card` | 0 0 8px #bbb | カード・メニューの影 |
+
+ルール:
+
+- 上記の意味に当てはまる色は必ず変数で書く。ハードコードしない
+- 新しい色が繰り返し必要になったら、まず `:root` に変数を追加してから使う
+- 1箇所だけの装飾的な色（バッジの黄色など）は直書きでよい
+- ベンダーCSS（`skyblue/`）と minify 済みファイルは触らない
+
+## ブレイクポイント
+
+CSS 変数はメディアクエリの条件には使えないため、値は直書きです。この表を正とします。
+
+| 幅 | 意味 |
+|---|---|
+| `max-width: 480px` | 最小スマホ調整（body フォント 15px 化など） |
+| `max-width: 697px` | ヘッダー・メインメニュー・ロゴの縮小 |
+| `max-width: 768px` | **スマホレイアウトの主境界**（テーブル・コンテンツの切替） |
+| `max-width: 969px` | フッターの縦積み |
+| `max-width: 1024px` | タブレット調整 |
+
+新しいブレイクポイントを増やさず、この5つに寄せてください。
+
+## クラス命名
+
+ページ名をプレフィックスにしたフラットな命名です（例: `contestresult-table-col-place`、`ranking-puzzle-brand`）。共通部品は `footer-nav-item` のように部品名プレフィックス。新しいスタイルもこの規則に合わせてください。
+
+## 動作確認
+
+```
+http://localhost:5000
+```
+
+- 結果ページ: `/contest/result/<cid>/<eid>`（実データのコンテスト ID は Firebase の `inProgress` を参照）
+- 参加者が多いコンテスト（300行超）でテーブル系の変更を確認すること
+- スマホ確認は DevTools のレスポンシブモードで 360〜768px を一通り

--- a/src/public/stylesheets/about.css
+++ b/src/public/stylesheets/about.css
@@ -12,13 +12,13 @@
 .about-hero-title {
   font-size: 22px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 12px;
 }
 
 .about-hero-subtitle {
   font-size: 14px;
-  color: #808080;
+  color: var(--color-text);
   line-height: 1.8;
   max-width: 600px;
   margin: 0 auto;
@@ -34,7 +34,7 @@
 
 .about-card {
   background: #ffffff;
-  border: 1px solid #e6e6e6;
+  border: 1px solid var(--color-text-light);
   border-radius: 12px;
   padding: 20px 24px;
 }
@@ -52,7 +52,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #009678;
+  color: var(--color-brand-2);
   font-size: 22px;
   flex-shrink: 0;
 }
@@ -66,12 +66,12 @@
 .about-card-title {
   font-size: 16px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin: 0;
 }
 
 .about-card-content {
-  color: #808080;
+  color: var(--color-text);
   font-size: 14px;
   line-height: 1.8;
 }
@@ -81,7 +81,7 @@
 }
 
 .about-card-content a:not(.about-cta-button) {
-  color: #0088cc;
+  color: var(--color-link);
 }
 
 /* Prize Table */
@@ -93,13 +93,13 @@
   font-size: 18px;
   font-weight: bold;
   text-align: center;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 8px;
 }
 
 .about-prize-subtitle {
   text-align: center;
-  color: #808080;
+  color: var(--color-text);
   font-size: 13px;
   margin-bottom: 16px;
 }
@@ -113,7 +113,7 @@
   width: 100%;
   max-width: 700px;
   margin: 0 auto;
-  color: #808080;
+  color: var(--color-text);
   border-collapse: collapse;
 }
 
@@ -121,12 +121,12 @@
 .about-prize-table td {
   padding: 12px 16px;
   text-align: center;
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .about-prize-table th {
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
 }
 
 .about-prize-table th.about-gold {
@@ -134,7 +134,7 @@
 }
 
 .about-prize-table th.about-silver {
-  color: #999999;
+  color: var(--color-text-muted);
 }
 
 .about-prize-table th.about-bronze {
@@ -147,7 +147,7 @@
 
 .about-prize-table .about-prize-amount {
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
 }
 
 /* CTA Buttons */
@@ -164,7 +164,7 @@
   align-items: center;
   gap: 6px;
   padding: 10px 20px;
-  background: #0088cc;
+  background: var(--color-link);
   color: #ffffff !important;
   border-radius: 8px;
   text-decoration: none !important;
@@ -179,19 +179,19 @@
 
 .about-cta-button-secondary {
   background: #ffffff;
-  color: #0088cc !important;
-  border: 1px solid #0088cc;
+  color: var(--color-link) !important;
+  border: 1px solid var(--color-link);
 }
 
 .about-cta-button-secondary:hover {
   background: #f5fbff;
-  color: #0088cc !important;
+  color: var(--color-link) !important;
   opacity: 1;
 }
 
 /* Info Box */
 .about-info-box {
-  background: #f7f7f7;
+  background: var(--color-surface-muted);
   border-radius: 8px;
   padding: 16px 20px;
   margin: 16px 0;
@@ -199,7 +199,7 @@
 
 .about-info-box-title {
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 8px;
   font-size: 14px;
   display: flex;
@@ -208,19 +208,19 @@
 }
 
 .about-info-box-content {
-  color: #808080;
+  color: var(--color-text);
   font-size: 13px;
   line-height: 1.7;
 }
 
 .about-info-box-content i {
-  color: #009678;
+  color: var(--color-brand-2);
   margin-right: 8px;
 }
 
 /* Icon styles */
 .about-icon-store {
-  color: #0088cc;
+  color: var(--color-link);
 }
 
 /* Responsive adjustments */

--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -1,6 +1,6 @@
 /* コンテスト情報 */
 .contestresult-info {
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 20px;
 }
 
@@ -9,7 +9,7 @@
   font-weight: bold;
   text-align: center;
   margin-bottom: 24px;
-  background: linear-gradient(to bottom, #0096AF, #009678);
+  background: var(--gradient-brand-vertical);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -52,7 +52,7 @@
 .contestresult-picker-season-label {
   font-size: 12px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   padding: 0 10px;
   height: 34px;
   white-space: nowrap;
@@ -74,7 +74,7 @@
   inset: 0;
   border-radius: 8px;
   padding: 1px;
-  background: linear-gradient(to bottom, #0096AF, #009678);
+  background: var(--gradient-brand-vertical);
   -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
@@ -103,7 +103,7 @@
   justify-content: center;
   font-size: 12px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -112,22 +112,22 @@
 }
 
 .contestresult-picker-contest-item:hover {
-  color: #555;
-  background-color: #f5f5f5;
+  color: var(--color-text-strong);
+  background-color: var(--color-surface-hover);
 }
 
 .contestresult-picker-contest-item.active {
-  color: #808080;
+  color: var(--color-text);
   font-weight: bold;
 }
 
 .contestresult-picker-contest-item.disabled {
-  color: #CCC;
+  color: var(--color-border);
   cursor: default;
 }
 
 .contestresult-picker-contest-item.disabled:hover {
-  color: #CCC;
+  color: var(--color-border);
   background-color: transparent;
 }
 
@@ -141,7 +141,7 @@
   margin-bottom: 16px;
   background-color: #fff;
   border-radius: 8px;
-  box-shadow: 0 0 8px #bbbbbb;
+  box-shadow: var(--shadow-card);
 }
 
 .contestresult-picker-event-item {
@@ -149,7 +149,7 @@
   flex-direction: column;
   align-items: center;
   padding: 0;
-  color: #808080;
+  color: var(--color-text);
   border: none;
   border-radius: 6px;
   cursor: pointer;
@@ -161,12 +161,12 @@
 }
 
 .contestresult-picker-event-item:hover {
-  color: #555;
-  background-color: #e8e8e8;
+  color: var(--color-text-strong);
+  background-color: var(--color-surface-hover);
 }
 
 .contestresult-picker-event-item.active {
-  color: #808080;
+  color: var(--color-text);
 }
 
 .contestresult-picker-event-icon {
@@ -177,7 +177,7 @@
 .contestresult-picker-event-label {
   font-size: 12px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   white-space: nowrap;
   line-height: 1;
   margin: 0;
@@ -201,7 +201,7 @@
   right: 0;
   top: 50%;
   height: 2px;
-  background: linear-gradient(to right, #0096AF, #009678);
+  background: var(--gradient-brand-horizontal);
 }
 
 .contestresult-divider-icon {
@@ -225,7 +225,7 @@
 .contestresult-puzzle-section-title {
   font-size: 16px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 8px;
 }
 
@@ -279,7 +279,7 @@
 .contestresult-puzzle-name {
   font-size: 16px;
   font-weight: bold;
-  color: #0088CC;
+  color: var(--color-link);
   text-decoration: none;
   display: block;
   white-space: nowrap;
@@ -288,11 +288,11 @@
 }
 
 a.contestresult-puzzle-name:hover {
-  color: #006699;
+  color: var(--color-link-hover);
 }
 
 .contestresult-puzzle-name-other {
-  color: #808080;
+  color: var(--color-text);
 }
 
 
@@ -301,14 +301,14 @@ a.contestresult-puzzle-name:hover {
   width: 48px;
   font-size: 16px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   text-align: right;
   flex-shrink: 0;
 }
 
 /* 種目カード (contest.html) */
 .contest-event-card {
-  border: 1px solid #CCC;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 12px;
   margin-bottom: 24px;
@@ -320,7 +320,7 @@ a.contestresult-puzzle-name:hover {
   gap: 8px;
   padding: 8px 12px;
   margin: -12px -12px 8px;
-  border-bottom: 1px solid #CCC;
+  border-bottom: 1px solid var(--color-border);
   border-radius: 8px 8px 0 0;
   text-decoration: none;
   cursor: pointer;
@@ -328,7 +328,7 @@ a.contestresult-puzzle-name:hover {
 }
 
 .contest-event-card-header:hover {
-  background-color: #f5f5f5;
+  background-color: var(--color-surface-hover);
 }
 
 .contest-event-card-icon {
@@ -338,7 +338,7 @@ a.contestresult-puzzle-name:hover {
 .contest-event-card-title {
   font-size: 16px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
 }
 
 .contest-event-card-right {
@@ -351,7 +351,7 @@ a.contestresult-puzzle-name:hover {
 .contest-event-card-participants {
   font-size: 16px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
 }
 
 
@@ -389,13 +389,13 @@ a.contestresult-puzzle-name:hover {
 .contestresult-scramble-title {
   font-size: 16px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 8px;
 }
 
 .contestresult-scramble-table {
   width: 100%;
-  color: #808080;
+  color: var(--color-text);
 }
 
 .contestresult-scramble-item {
@@ -403,7 +403,7 @@ a.contestresult-puzzle-name:hover {
 }
 
 .contestresult-scramble-item:nth-child(odd) {
-  background-color: #f9f9f9;
+  background-color: var(--color-surface-muted);
 }
 
 .contestresult-scramble-number {
@@ -411,7 +411,7 @@ a.contestresult-puzzle-name:hover {
   font-weight: bold;
   text-align: center;
   vertical-align: middle;
-  color: #808080;
+  color: var(--color-text);
 }
 
 .contestresult-scramble-text {
@@ -422,14 +422,14 @@ a.contestresult-puzzle-name:hover {
 
 /* テーブル */
 .contestresult-table {
-  color: #808080;
+  color: var(--color-text);
   table-layout: fixed;
   width: 100%;
 }
 
 .contestresult-table-header {
   font-weight: bold;
-  border-bottom: 1px solid #CCC;
+  border-bottom: 1px solid var(--color-border);
   height: 40px;
 }
 
@@ -446,7 +446,7 @@ a.contestresult-puzzle-name:hover {
 }
 
 .contestresult-table-body-item:nth-child(5n) {
-  border-bottom: 1px solid #CCC;
+  border-bottom: 1px solid var(--color-border);
 }
 
 /* 共通: flexで中央揃え・高さ48pxのセル内レイアウト */
@@ -518,21 +518,21 @@ a.contestresult-puzzle-name:hover {
 }
 
 .contestresult-table-link {
-  color: #0088CC;
+  color: var(--color-link);
   font-weight: bold;
 }
 
 .contestresult-table-link:hover {
-  color: #006699;
+  color: var(--color-link-hover);
 }
 
 .contestresult-table-link-default-color {
-  color: #0088CC;
+  color: var(--color-link);
   font-weight: bold;
 }
 
 .contestresult-table-link-default-color:hover {
-  color: #006699;
+  color: var(--color-link-hover);
 }
 
 .contestresult-table-deploy-button {
@@ -564,7 +564,7 @@ a.contestresult-puzzle-name:hover {
 .contestresult-table-detail-records.deploy {
   width: 408px;
   padding-left: 4px;
-  color: #808080;
+  color: var(--color-text);
 }
 
 .contestresult-table.animating tbody tr:nth-child(n+41) {

--- a/src/public/stylesheets/index.css
+++ b/src/public/stylesheets/index.css
@@ -1,9 +1,9 @@
 .index-content {
-  color: #808080;
+  color: var(--color-text);
 }
 
 .index-content a:not(.index-event-row) {
-  color: #0088cc;
+  color: var(--color-link);
 }
 
 .index-lead {
@@ -13,7 +13,7 @@
 }
 
 .index-info-card {
-  border: 1px solid #e6e6e6;
+  border: 1px solid var(--color-text-light);
   border-radius: 12px;
   padding: 16px 20px;
   margin-bottom: 16px;
@@ -22,7 +22,7 @@
 .index-info-title {
   font-size: 15px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 8px;
 }
 
@@ -36,7 +36,7 @@
   display: inline-block;
   padding: 8px 16px;
   border-radius: 8px;
-  background: #0088cc;
+  background: var(--color-link);
   color: #ffffff;
   font-size: 13px;
   font-weight: bold;
@@ -79,7 +79,7 @@
 .index-contest-card {
   max-width: 520px;
   margin: 0 auto 24px;
-  box-shadow: 0 0 8px #bbbbbb;
+  box-shadow: var(--shadow-card);
   border-radius: 12px;
   padding: 20px 24px 0;
 }
@@ -89,7 +89,7 @@
   text-align: center;
   font-size: 20px;
   font-weight: bold;
-  background: linear-gradient(to bottom, #0096af, #009678);
+  background: var(--gradient-brand-vertical);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -100,7 +100,7 @@
   font-size: 12px;
   font-weight: bold;
   margin-bottom: 12px;
-  background: linear-gradient(to bottom, #0096af, #009678);
+  background: var(--gradient-brand-vertical);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -108,7 +108,7 @@
 
 .index-event-list {
   margin: 0 -24px;
-  border-top: 1px solid #e6e6e6;
+  border-top: 1px solid var(--color-text-light);
 }
 
 .index-event-section {
@@ -116,7 +116,7 @@
 }
 
 .index-event-section + .index-event-section {
-  border-top: 1px solid #e6e6e6;
+  border-top: 1px solid var(--color-text-light);
 }
 
 .index-event-row {
@@ -124,14 +124,14 @@
   align-items: center;
   height: 44px;
   padding: 0 8px;
-  color: #808080;
+  color: var(--color-text);
   text-decoration: none;
   transition: background-color 0.2s ease;
 }
 
 .index-event-row:hover {
-  background: #fafafa;
-  color: #808080;
+  background: var(--color-surface-hover);
+  color: var(--color-text);
 }
 
 .index-event-check {
@@ -154,7 +154,7 @@
 .index-event-resume-icon {
   font-size: 21px;
   line-height: 1;
-  color: #e74c3c;
+  color: var(--color-error);
 }
 
 .index-event-done {
@@ -190,7 +190,7 @@
   padding: 3px 0;
   border-radius: 4px;
   white-space: nowrap;
-  color: #808080;
+  color: var(--color-text);
 }
 
 .index-format-average {
@@ -216,7 +216,7 @@
   text-align: right;
   font-size: 12px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   white-space: nowrap;
 }
 

--- a/src/public/stylesheets/login.css
+++ b/src/public/stylesheets/login.css
@@ -10,26 +10,26 @@
   padding: 32px;
   background: #ffffff;
   border-radius: 12px;
-  border: 1px solid #dddddd;
+  border: 1px solid var(--color-border-light);
 }
 
 .auth-title {
   font-size: 22px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   text-align: center;
   margin-bottom: 24px;
 }
 
 .auth-desc {
   font-size: 13px;
-  color: #808080;
+  color: var(--color-text);
   line-height: 1.6;
   margin-bottom: 20px;
 }
 
 .auth-desc a {
-  color: #0088cc;
+  color: var(--color-link);
 }
 
 .auth-field {
@@ -40,7 +40,7 @@
   display: block;
   font-size: 13px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 4px;
 }
 
@@ -50,13 +50,13 @@
   box-sizing: border-box;
   padding: 10px 12px;
   font-size: 14px;
-  border: 1px solid #dddddd;
+  border: 1px solid var(--color-border-light);
   border-radius: 8px;
   transition: border-color 0.2s ease;
 }
 
 .auth-input:focus {
-  border-color: #0096af;
+  border-color: var(--color-brand-1);
   outline: none;
 }
 
@@ -66,7 +66,7 @@
   padding: 12px;
   border: none;
   border-radius: 8px;
-  background: #0088cc;
+  background: var(--color-link);
   color: #ffffff;
   font-size: 15px;
   font-weight: bold;
@@ -86,12 +86,12 @@
 
 .auth-notice-success {
   background: #e8f7f3;
-  color: #1bbc9b;
+  color: var(--color-success);
 }
 
 .auth-notice-error {
   background: #fdecea;
-  color: #e74c3c;
+  color: var(--color-error);
 }
 
 .auth-links {
@@ -103,10 +103,10 @@
 }
 
 .auth-links a {
-  color: #0088cc;
+  color: var(--color-link);
   font-size: 13px;
 }
 
 .auth-links a:hover {
-  color: #006699;
+  color: var(--color-link-hover);
 }

--- a/src/public/stylesheets/main.css
+++ b/src/public/stylesheets/main.css
@@ -2,6 +2,46 @@
  * main.css
  */
 
+/**
+ * カラーパレット
+ * 色は必ずここの変数を使う。新しい色が必要な場合はまず変数を追加する。
+ * 詳細は docs/frontend.md を参照。
+ */
+:root {
+  /* ブランドカラー (ヘッダー・フッター・アクティブ状態) */
+  --color-brand-1: #0096af;
+  --color-brand-2: #009678;
+  --gradient-brand: linear-gradient(-15deg, var(--color-brand-2), var(--color-brand-1));
+  --gradient-brand-vertical: linear-gradient(to bottom, var(--color-brand-1), var(--color-brand-2));
+  --gradient-brand-horizontal: linear-gradient(to right, var(--color-brand-1), var(--color-brand-2));
+
+  /* テキスト */
+  --color-text: #808080;         /* 基本テキスト */
+  --color-text-strong: #555;     /* 強調・ホバー */
+  --color-text-muted: #999;      /* 補助テキスト */
+  --color-text-light: #e6e6e6;   /* 濃い背景上の明るいテキスト (フッター等) */
+
+  /* リンク */
+  --color-link: #0088cc;
+  --color-link-hover: #006699;
+
+  /* 背景 */
+  --color-surface-hover: #f5f5f5;  /* ホバー背景 */
+  --color-surface-muted: #f7f7f7;  /* 淡い背景 (パネル・ゼブラ・表ヘッダ) */
+
+  /* ボーダー */
+  --color-border: #ccc;
+  --color-border-light: #ddd;
+  --color-border-lighter: #ececec;
+
+  /* 状態 */
+  --color-error: #e74c3c;
+  --color-success: #1bbc9b;
+
+  /* 影 */
+  --shadow-card: 0 0 8px #bbbbbb;
+}
+
 body {
   background-color: #fff;
   font-family: "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", "メイリオ",
@@ -9,7 +49,7 @@ body {
 }
 
 .contesttimer-page {
-  color: #808080;
+  color: var(--color-text);
 }
 h1,
 h2,
@@ -44,7 +84,7 @@ h6 {
 }
 
 #header-background {
-  background: linear-gradient(-15deg, #009678, #0096af);
+  background: var(--gradient-brand);
   height: 64px;
   left: 50%;
   position: absolute;
@@ -93,9 +133,9 @@ h6 {
 #main-menu a {
   align-items: center;
   border-radius: 8px;
-  box-shadow: 0 0 8px #bbbbbb;
+  box-shadow: var(--shadow-card);
   box-sizing: border-box;
-  color: #808080;
+  color: var(--color-text);
   display: flex;
   flex-shrink: 0;
   gap: 2px;
@@ -107,7 +147,7 @@ h6 {
 }
 
 #main-menu .active {
-  background: linear-gradient(-15deg, #009678, #0096af);
+  background: var(--gradient-brand);
   color: #ffffff;
 }
 
@@ -194,7 +234,7 @@ body > .container {
   display: flex;
   align-items: center;
   padding: 8px 0;
-  color: #e6e6e6;
+  color: var(--color-text-light);
   font-size: 14px;
 }
 
@@ -206,7 +246,7 @@ body > .container {
   left: 50%;
   transform: translateX(-50%);
   width: 100vw;
-  background: linear-gradient(-15deg, #009678, #0096af);
+  background: var(--gradient-brand);
   z-index: -1;
 }
 
@@ -230,7 +270,7 @@ body > .container {
   display: inline-flex;
   align-items: center;
   gap: 2px;
-  color: #e6e6e6;
+  color: var(--color-text-light);
   font-size: 14px;
   font-weight: 600;
   text-decoration: none;
@@ -242,7 +282,7 @@ body > .container {
 }
 
 .footer-nav-item:hover {
-  color: #e6e6e6;
+  color: var(--color-text-light);
   opacity: 0.85;
 }
 
@@ -253,7 +293,7 @@ body > .container {
   width: 100%;
   height: 2px;
   border-radius: 1px;
-  background: #e6e6e6;
+  background: var(--color-text-light);
 }
 
 #footer-copyright {
@@ -262,7 +302,7 @@ body > .container {
 }
 
 #footer-copyright a {
-  color: #e6e6e6;
+  color: var(--color-text-light);
   text-decoration: underline;
 }
 
@@ -285,19 +325,19 @@ body > .container {
  * Auth Info
  */
 #auth-info {
-  color: #808080;
+  color: var(--color-text);
 }
 
 #event-info {
-  color: #808080;
+  color: var(--color-text);
 }
 
 .contestform-page {
-  color: #808080;
+  color: var(--color-text);
 }
 
 a.underlined {
-  color: #e74c3c;
+  color: var(--color-error);
   text-decoration: underline;
 }
 
@@ -307,9 +347,9 @@ a.underlined {
 .notice-error {
   padding: 10px;
   background: none;
-  color: #e74c3c;
-  border: 2px solid #e74c3c;
-  border-top: 5px solid #e74c3c;
+  color: var(--color-error);
+  border: 2px solid var(--color-error);
+  border-top: 5px solid var(--color-error);
   /*-webkit-border-radius: 5px;
        -moz-border-radius: 5px;
             border-radius: 5px;*/
@@ -317,9 +357,9 @@ a.underlined {
 .notice-success {
   padding: 10px;
   background: none;
-  color: #1bbc9b;
-  border: 2px solid #1bbc9b;
-  border-top: 5px solid #1bbc9b;
+  color: var(--color-success);
+  border: 2px solid var(--color-success);
+  border-top: 5px solid var(--color-success);
   /*-webkit-border-radius: 5px;
        -moz-border-radius: 5px;
             border-radius: 5px;*/
@@ -327,9 +367,9 @@ a.underlined {
 .notice-normal {
   padding: 10px;
   background: none;
-  color: #555;
-  border: 2px solid #555;
-  border-top: 5px solid #555;
+  color: var(--color-text-strong);
+  border: 2px solid var(--color-text-strong);
+  border-top: 5px solid var(--color-text-strong);
   /*-webkit-border-radius: 5px;
        -moz-border-radius: 5px;
             border-radius: 5px;*/
@@ -387,7 +427,7 @@ table.scrambles {
   margin-bottom: 20px;
 }
 table.scrambles tr.scramble-done {
-  color: #ddd;
+  color: var(--color-border-light);
 }
 table.scrambles td,
 table.scrambles th {
@@ -421,7 +461,7 @@ table.scrambles th:first-child {
 }
 
 .timeform {
-  border: 1px solid rgb(236, 236, 236);
+  border: 1px solid var(--color-border-lighter);
   -webkit-border-radius: 10px;
   -moz-border-radius: 10;
   border-radius: 10px;
@@ -434,14 +474,14 @@ table.scrambles th:first-child {
   padding-bottom: 10px;
   margin-top: 10px;
   margin-bottom: 10px;
-  border-bottom: 1px solid rgb(236, 236, 236);
+  border-bottom: 1px solid var(--color-border-lighter);
   text-align: center;
 }
 
 .timeform-time input {
   width: 100%;
   font-size: 24px;
-  border: 2px solid #ddd;
+  border: 2px solid var(--color-border-light);
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
@@ -454,13 +494,13 @@ table.scrambles th:first-child {
   outline: none;
 }
 .timeform-time input.format-error {
-  border: 2px solid #e74c3c;
+  border: 2px solid var(--color-error);
 }
 .timeform-time span.result-detail {
   font-size: 24px;
 }
 .timeform-time span.yet {
-  color: #ddd;
+  color: var(--color-border-light);
 }
 .timeform-time span.result-note {
   font-size: 12px;
@@ -475,7 +515,7 @@ table.scrambles th:first-child {
 
 .timeform-cond-btn {
   display: inline-block;
-  border: 1px solid rgb(236, 236, 236);
+  border: 1px solid var(--color-border-lighter);
   width: 40px;
   height: 40px;
   -webkit-border-radius: 20px;
@@ -488,7 +528,7 @@ table.scrambles th:first-child {
 }
 
 .cond-ok-on {
-  background-color: #1bbc9b;
+  background-color: var(--color-success);
   color: #fff;
 }
 .cond-penalty-on {
@@ -496,7 +536,7 @@ table.scrambles th:first-child {
   color: #fff;
 }
 .cond-dnf-on {
-  background-color: #e74c3c;
+  background-color: var(--color-error);
   color: #fff;
 }
 
@@ -504,14 +544,14 @@ table.scrambles th:first-child {
  * Table format
  */
 table.tribox-contest {
-  border-left: 1px solid #ddd;
+  border-left: 1px solid var(--color-border-light);
 }
 table.tribox-contest th,
 table.tribox-contest td {
   border-left: none;
 }
 table.tribox-contest tr:first-child > th {
-  background-color: #f7f7f7;
+  background-color: var(--color-surface-muted);
 }
 
 /**
@@ -524,7 +564,7 @@ table.inProgress {
   font-size: 95%;
 }
 table.inProgress {
-  border-left: 1px solid #ddd;
+  border-left: 1px solid var(--color-border-light);
 }
 table.inProgress th,
 table.inProgress td {
@@ -539,7 +579,7 @@ a.cursor-pointer {
 }
 tr.row-detail {
   background: #fff !important; /*background: #F7F7F9;*/
-  border: 1px solid #e1e1e8;
+  border: 1px solid var(--color-border-lighter);
 }
 
 .color-star {
@@ -624,7 +664,7 @@ table.profile td {
   width: 16px;
   height: 16px;
   border-radius: 3px;
-  background-image: linear-gradient(-15deg, #009678, #0096af);
+  background-image: var(--gradient-brand);
   background-size: 56px 56px;
   opacity: 0.2;
   animation: cube-loader-pulse 1.2s infinite ease-in-out;
@@ -647,6 +687,6 @@ table.profile td {
 
 .cube-loader-text {
   margin-top: 12px;
-  color: #808080;
+  color: var(--color-text);
   font-size: 14px;
 }

--- a/src/public/stylesheets/ranking.css
+++ b/src/public/stylesheets/ranking.css
@@ -19,13 +19,13 @@ html {
 .ranking-title {
   font-size: 22px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 4px;
 }
 
 .ranking-period {
   font-size: 13px;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 0;
 }
 
@@ -35,11 +35,11 @@ html {
 }
 
 .ranking-puzzle-switch a {
-  color: #0088cc;
+  color: var(--color-link);
 }
 
 .ranking-puzzle-switch a:hover {
-  color: #006699;
+  color: var(--color-link-hover);
 }
 
 .ranking-event-section {
@@ -52,19 +52,19 @@ html {
   gap: 8px;
   font-size: 18px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin: 0 0 8px;
 }
 
 .ranking-table {
-  color: #808080;
+  color: var(--color-text);
   table-layout: fixed;
   width: 100%;
 }
 
 .ranking-table-header {
   font-weight: bold;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--color-border);
   height: 40px;
 }
 
@@ -82,7 +82,7 @@ html {
 }
 
 .ranking-table-row:nth-child(5n) {
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .ranking-cell-padded {
@@ -116,7 +116,7 @@ html {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: #0088cc;
+  color: var(--color-link);
   text-decoration: none;
 }
 
@@ -137,7 +137,7 @@ html {
 }
 
 .ranking-link:hover {
-  color: #006699;
+  color: var(--color-link-hover);
 }
 
 .ranking-season-picker {

--- a/src/public/stylesheets/regulations.css
+++ b/src/public/stylesheets/regulations.css
@@ -1,18 +1,18 @@
 .regulations-content {
-  color: #808080;
+  color: var(--color-text);
 }
 
 .regulations-content h2 {
   font-size: 22px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 12px;
 }
 
 .regulations-content h4 {
   font-size: 16px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-top: 32px;
   margin-bottom: 8px;
 }
@@ -33,12 +33,12 @@
 }
 
 .regulations-content a {
-  color: #0088cc;
+  color: var(--color-link);
 }
 
 .regulations-content hr {
   border: none;
-  border-top: 1px solid #e6e6e6;
+  border-top: 1px solid var(--color-text-light);
   margin: 32px 0;
 }
 

--- a/src/public/stylesheets/timer.css
+++ b/src/public/stylesheets/timer.css
@@ -62,10 +62,10 @@ body {
 }
 
 .wait {
-    color: #E74C3C !important;
+    color: var(--color-error) !important;
 }
 .ready {
-    color: #1BBC9B !important;
+    color: var(--color-success) !important;
 }
 
 

--- a/src/public/stylesheets/toggle.css
+++ b/src/public/stylesheets/toggle.css
@@ -13,10 +13,10 @@ div.switch {
 }
 
 #sound-off {
-    color: #dddddd;
+    color: var(--color-border-light);
 }
 #sound-on {
-    color: #1bbc9b;
+    color: var(--color-success);
 }
 
 label.toggle-label {
@@ -41,7 +41,7 @@ input.cmn-toggle-round-flat + label {
     padding: 2px;
     width: 45px;
     height: 24px;
-    background-color: #dddddd;
+    background-color: var(--color-border-light);
     border-radius: 30px;
     transition: background 0.4s;
 }
@@ -65,14 +65,14 @@ input.cmn-toggle-round-flat + label:after {
     left: 4px;
     bottom: 4px;
     width: 17px;
-    background-color: #dddddd;
+    background-color: var(--color-border-light);
     border-radius: 17px;
     transition: margin 0.4s, background 0.4s;
 }
 input.cmn-toggle-round-flat:checked + label {
-    background-color: #1bbc9b;
+    background-color: var(--color-success);
 }
 input.cmn-toggle-round-flat:checked + label:after {
     margin-left: 20px;
-    background-color: #1bbc9b;
+    background-color: var(--color-success);
 }

--- a/src/public/stylesheets/user.css
+++ b/src/public/stylesheets/user.css
@@ -10,14 +10,14 @@ html {
 .user-section-title {
   font-size: 20px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin: 40px 0 16px;
 }
 
 .user-subtitle {
   font-size: 16px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin: 0 0 12px;
 }
 
@@ -25,24 +25,24 @@ html {
 .user-name {
   font-size: 22px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 16px;
 }
 
 .user-name .user-verified {
-  color: #0088cc;
+  color: var(--color-link);
   font-size: 18px;
 }
 
 .user-name .user-id {
   font-size: 14px;
   font-weight: normal;
-  color: #b3b3b3;
+  color: var(--color-text-muted);
   margin-left: 4px;
 }
 
 .user-profile-table {
-  color: #808080;
+  color: var(--color-text);
   border-collapse: collapse;
   margin-bottom: 32px;
 }
@@ -64,11 +64,11 @@ html {
 }
 
 .user-profile-table a {
-  color: #0088cc;
+  color: var(--color-link);
 }
 
 .user-profile-table a:hover {
-  color: #006699;
+  color: var(--color-link-hover);
 }
 
 /* 過去シーズン選択カルーセル (contestresult-picker-contest を流用) */
@@ -82,7 +82,7 @@ html {
 /* 記録なしの案内 */
 .user-empty-note {
   font-size: 14px;
-  color: #808080;
+  color: var(--color-text);
   margin: 8px 0 24px;
 }
 
@@ -93,13 +93,13 @@ html {
   gap: 8px;
   font-size: 18px;
   font-weight: bold;
-  color: #808080;
+  color: var(--color-text);
   margin: 32px 0 8px;
 }
 
 .user-event-sp {
   font-size: 14px;
-  color: #808080;
+  color: var(--color-text);
   margin-bottom: 12px;
 }
 
@@ -140,7 +140,7 @@ html {
 /* ビデオ公開予約の注意書き */
 .user-video-note {
   font-size: 14px;
-  color: #808080;
+  color: var(--color-text);
   line-height: 1.8;
   margin: 8px 0 40px;
 }
@@ -150,11 +150,11 @@ html {
 }
 
 .user-video-note a {
-  color: #0088cc;
+  color: var(--color-link);
 }
 
 .user-video-note a:hover {
-  color: #006699;
+  color: var(--color-link-hover);
 }
 
 /* カラムの揃えを左に統一 */
@@ -193,8 +193,8 @@ html {
   margin: 0 8px 0 0;
   padding: 6px 10px;
   font-size: 14px;
-  color: #808080;
-  border: 1px solid #e6e6e6;
+  color: var(--color-text);
+  border: 1px solid var(--color-text-light);
   border-radius: 6px;
   vertical-align: middle;
 }
@@ -202,7 +202,7 @@ html {
 .user-video-btn {
   display: inline-block;
   padding: 7px 16px;
-  background: #0088cc;
+  background: var(--color-link);
   color: #ffffff !important;
   font-size: 14px;
   font-weight: bold;


### PR DESCRIPTION
## 変更内容

フロントエンドの色をCSS変数に集約し、今後フロントエンドを触る人向けのガイドを追加しました。

### CSS変数化（11ファイル・約200箇所）
`main.css` 先頭の `:root` にカラーパレットを定義し、全ページのCSSを変数参照に置き換えました。

- ブランド: `--color-brand-1/2`（#0096af / #009678）とグラデーション3方向（`--gradient-brand` / `-vertical` / `-horizontal`）
- テキスト: `--color-text`（#808080）/ `--color-text-strong`（#555）/ `--color-text-muted`（#999）/ `--color-text-light`（#e6e6e6）
- リンク: `--color-link` / `--color-link-hover`
- 背景: `--color-surface-hover`（#f5f5f5）/ `--color-surface-muted`（#f7f7f7）
- ボーダー: `--color-border` / `--color-border-light` / `--color-border-lighter`
- 状態: `--color-error` / `--color-success`、影: `--shadow-card`

あわせて、ほぼ同じ用途で微妙に値が違っていたグレー系を統一しています（意図的な視覚変化）:

- ホバー背景: #fafafa・#e8e8e8 → #f5f5f5
- ゼブラ・パネル背景: #f9f9f9 → #f7f7f7
- 補助テキスト: #b3b3b3 → #999
- 極薄ボーダー: rgb(236,236,236)・#e1e1e8 → #ececec

1箇所しか使われない装飾色（バッジ・タイマー状態色・ステータス淡色背景など）と白は直書きのまま、ベンダーCSS（skyblue）は不触です。

### docs/frontend.md を新規追加
フロントエンドのルール集です。

- Jinja（`[[ ]]`）と Angular（`{{ }}`）のデリミタの説明
- **ng-src 必須ルール**（`src="{{ }}"` によるゴミリクエストの再発防止）
- カラー変数一覧と「新しい色はまず変数に追加」のルール
- ブレイクポイント5種（480 / 697 / 768 / 969 / 1024）の意味と「新設しない」ルール
- クラス命名規則、動作確認の手順

## 確認
- ヘッダー/フッターのグラデーション、テーブル文字色、リンク色などが変数経由で従来と同一の色に解決されることを computed style で確認
- グレー統一で変わる箇所（種目ピッカーのホバー、スクランブルのゼブラ）は目視で確認

- 追記: ランキング表のリンク（`.ranking-link`）に `font-weight: bold` を追加し、リザルトページのリンクと太さを揃えました
