### PR TITLE
Fix double ng- prefix on already-converted ng-src attributes

### DIFF
--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -79,7 +79,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         <img
                           class="contestresult-puzzle-brand"
                           ng-if="p.brand"
-                          ng-ng-src="https://store.tribox.com/user_data/img/category/{{ p.brand }}.png"
+                          ng-src="https://store.tribox.com/user_data/img/category/{{ p.brand }}.png"
                           height="24"
                         />
                         <span class="contestresult-puzzle-brand-placeholder" ng-if="!p.brand"></span>
@@ -112,7 +112,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                         <img
                           class="contestresult-puzzle-brand"
                           ng-if="p.brand"
-                          ng-ng-src="https://store.tribox.com/user_data/img/category/{{ p.brand }}.png"
+                          ng-src="https://store.tribox.com/user_data/img/category/{{ p.brand }}.png"
                           height="24"
                         />
                         <span class="contestresult-puzzle-brand-placeholder" ng-if="!p.brand"></span>

--- a/src/templates/ranking.html
+++ b/src/templates/ranking.html
@@ -131,7 +131,7 @@
                       >
                         <img
                           class="ranking-puzzle-brand"
-                          ng-ng-src="https://store.tribox.com/user_data/img/category/{{ data.lastUsedPuzzleBrand }}.png"
+                          ng-src="https://store.tribox.com/user_data/img/category/{{ data.lastUsedPuzzleBrand }}.png"
                           height="24"
                         />
                       </a>


### PR DESCRIPTION
## 変更内容

#280 の `src` → `ng-src` 一括置換の際、**既に `ng-src` だった3箇所**にも `src="https://store...` の部分文字列が置換にマッチしてしまい、`ng-ng-src` という壊れた属性になっていました。Angularが認識できないためロゴの `src` が設定されず、以下の箇所でメーカーロゴが表示されなくなっていました。

- SPランキングのパズル列のメーカーロゴ（ranking.html）
- コンテスト結果ページの「参加者全員のパズル」「入賞者のパズル」セクションのロゴ（contestresult.html ×2）

`ng-ng-src` → `ng-src` に修正しています。

## 確認
実ブラウザで、SPランキング（ロゴ540個）・リザルトのパズル使用率（10個）・コンテストページ（42個）すべて表示され、壊れた画像が0件であることを確認しました。