### PR TITLE
Replace lottery crown icon with Font Awesome gift icon

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -485,10 +485,9 @@ a.contestresult-puzzle-name:hover {
   max-width: 100%;
 }
 
-.contestresult-lottery-crown {
-  height: 16px;
-  width: auto;
-  max-width: none;
+.contestresult-lottery-gift {
+  font-size: 16px;
+  color: #f1c000;
   flex-shrink: 0;
   vertical-align: middle;
 }

--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -125,7 +125,7 @@
             <div class="about-card">
               <div class="about-card-header">
                 <div class="about-card-icon">
-                  <img src="/assets/images/icons/crown.png" alt="抽選ポイント" />
+                  <i class="fa fa-gift"></i>
                 </div>
                 <h3 class="about-card-title">抽選ポイント</h3>
               </div>

--- a/src/templates/contestresult.html
+++ b/src/templates/contestresult.html
@@ -189,7 +189,7 @@ contest_url + "/contest/result/" + cid + "/" + eid %]
                             {{ r.seasonPoint + r.seasonPointVideoBonus }}p
                           </span>
                           <span class="lottery" ng-show="r.lottery">
-                            <img class="contestresult-lottery-crown" src="/assets/images/icons/crown.png" alt="当選" />
+                            <i class="fa fa-gift contestresult-lottery-gift" title="当選"></i>
                           </span>
                         </div>
                       </td>

--- a/src/templates/user.html
+++ b/src/templates/user.html
@@ -315,7 +315,7 @@
                         <td class="contestresult-table-text-align-end">
                           {{ c.result.place }}位
                           <span class="lottery" ng-show="c.result.lottery">
-                            <img class="contestresult-lottery-crown" src="/assets/images/icons/crown.png" alt="当選" />
+                            <i class="fa fa-gift contestresult-lottery-gift" title="当選"></i>
                           </span>
                         </td>
                         <td class="contestresult-table-text-align-center">
@@ -461,7 +461,7 @@
                           <td class="contestresult-table-text-align-end">
                             {{ c.result.place }}位
                             <span class="lottery" ng-show="c.result.lottery">
-                              <img class="contestresult-lottery-crown" src="/assets/images/icons/crown.png" alt="当選" />
+                              <i class="fa fa-gift contestresult-lottery-gift" title="当選"></i>
                             </span>
                           </td>
                           <td class="contestresult-table-text-align-center">


### PR DESCRIPTION
## 変更内容

当選マークの王冠アイコン（crown.png）を Font Awesome の `fa-gift`（プレゼント）に置き換えました。

- 結果テーブル・ユーザーページの当選マーク: 金色（#f1c000）のギフトアイコンに変更
- aboutページの「抽選ポイント」カード: 他のカードと同じ素のFAアイコン形式に変更（色は他カードと同じブランドteal）
- CSS: `.contestresult-lottery-crown` → `.contestresult-lottery-gift`（画像サイズ指定からfont-size/colorに）
- `crown.png` 自体は削除していません

## 確認
結果ページで当選者40名の行すべてにアイコンが表示されること、aboutページのカードアイコンが他と揃うことをブラウザで確認しました。