### PR TITLE
Bold ranking links and add shadow to country flags

### DIFF
--- a/src/public/stylesheets/contestresult.css
+++ b/src/public/stylesheets/contestresult.css
@@ -483,6 +483,7 @@ a.contestresult-puzzle-name:hover {
 
 .contestresult-table-flag img {
   max-width: 100%;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.35);
 }
 
 .contestresult-lottery-crown {

--- a/src/public/stylesheets/ranking.css
+++ b/src/public/stylesheets/ranking.css
@@ -117,6 +117,7 @@ html {
   overflow: hidden;
   text-overflow: ellipsis;
   color: var(--color-link);
+  font-weight: bold;
   text-decoration: none;
 }
 

--- a/src/public/stylesheets/user.css
+++ b/src/public/stylesheets/user.css
@@ -216,3 +216,7 @@ html {
   opacity: 0.92;
   color: #ffffff !important;
 }
+
+.user-profile-flag {
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.35);
+}

--- a/src/templates/user.html
+++ b/src/templates/user.html
@@ -143,6 +143,7 @@
                       <span ng-show="!(thisUserData.iso2)">Loading...</span>
                       <span ng-show="thisUserData.iso2">
                         <img
+                          class="user-profile-flag"
                           ng-src="https://flagcdn.com/{{ thisUserData.iso2.toLowerCase() }}.svg"
                           height="16"
                           style="vertical-align: middle"


### PR DESCRIPTION
## 変更内容

小さな表示調整2件です。

### SPランキングのリンクを太字に
`.ranking-link`（競技者名・パズル名）に `font-weight: bold` を追加し、リザルトページのリンクと太さを揃えました。
※ #283 に含めたつもりだった修正ですが、pushとマージが行き違いになりマージ版から漏れていたため再適用です。

### 競技者の国旗に影を追加
`box-shadow: 0 0 2px rgba(0,0,0,0.35)` の控えめな影で、日本国旗のような白ベースの旗が白背景に溶けないようにしました。結果・ランキング・コンテスト（共通クラス）とユーザーページのプロフィール国旗に適用しています。